### PR TITLE
CONTRIBUTING: branch/PR flow, release branch, and ruleset guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,12 @@ I'm glad you're here. Let's all make Hoplight the best it can be!
   in as PRs against it, not direct pushes.
 - **`Mainstage` is also the release branch.** Every push to it triggers the release train: it bumps
   the version, tags, builds the binaries, and publishes a GitHub Release. That is another reason
-  changes arrive by PR, since a merge cuts a release and a stray direct push would too. Put
-  `[skip release]` in a commit message for a docs-only or tooling change that should not cut one.
+  changes arrive by PR, since a merge cuts a release and a stray direct push would too. For a
+  docs-only or tooling change that should not cut a release, put `[skip release]` in the commit that
+  lands on `Mainstage`. The train reads only that landing commit's message (`head_commit`), not the
+  individual PR commits, so for a squash or merge you must put the marker in the squash or merge
+  commit message itself (edit it before confirming); a marker buried in a branch commit is ignored
+  and the release still runs.
 - **CI must be green to merge.** Each PR runs `verify:ci` (the whole wall). The `test` check has to
   pass before a PR is merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,22 @@ I'm glad you're here. Let's all make Hoplight the best it can be!
 - **Explain new dependencies.** Include the package and why it is useful in the PR. The license audit
   rejects restricted licenses, and reviewers may suggest a small local helper when that is simpler.
 
+## How changes land
+
+- **Work on a branch, open a pull request.** `Mainstage` is the default branch; contributions come
+  in as PRs against it, not direct pushes.
+- **`Mainstage` is also the release branch.** Every push to it triggers the release train: it bumps
+  the version, tags, builds the binaries, and publishes a GitHub Release. That is another reason
+  changes arrive by PR, since a merge cuts a release and a stray direct push would too. Put
+  `[skip release]` in a commit message for a docs-only or tooling change that should not cut one.
+- **CI must be green to merge.** Each PR runs `verify:ci` (the whole wall). The `test` check has to
+  pass before a PR is merged.
+
+**Maintainer note (branch ruleset).** The recommended protection on `Mainstage` is to require the
+`test` status check, block force pushes, and add the GitHub Actions bot to the ruleset bypass list.
+The bypass is not optional: the release train pushes the version bump and tag directly, so without it
+on the bypass list, releases stop cutting.
+
 ## Adding a platform format
 
 Formats are drop-in folders. Copy `src/formats/_template/`, implement detect/read/write plus a


### PR DESCRIPTION
Documents how changes land so contributors (and the maintainer) share the model:

- Work on a branch, open a PR against Mainstage (no direct pushes).
- Mainstage is also the release branch: a merge cuts a release; [skip release] opts out.
- CI must be green (the test check) to merge.
- Maintainer note: the recommended branch ruleset must add the GitHub Actions bot to the bypass list, or the release train stops pushing its version bump and tag.

Docs-only. No em dashes; CONTRIBUTING is not in the docs-index corpus, so no regen.