### PR TITLE
Systemic audit (Fable 5): 6 findings, 4 executor-ready plans [skip release]

### DIFF
--- a/audit-plans/001-restore-regex-and-preset-cli-conversion.md
+++ b/audit-plans/001-restore-regex-and-preset-cli-conversion.md
@@ -1,0 +1,230 @@
+# Plan 001: Restore regex and preset conversion through the CLI
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: P1
+- Category: correctness
+- Effort: S-M
+- Risk: LOW
+- Depends on: none (soft: run 002 first, or apply Step 4's side-effect note)
+- Planned at: commit `80451e6`, 2026-07-24 (revised same day after adversarial review)
+- Finding: CORR-01 (+ TEST-01) in AUDIT.md
+
+## Outcome
+
+`hoplight convert` succeeds for every same-kind pair of registered adapters, including regex and
+preset; a cross-kind attempt still fails closed with an accurate message; a registry-driven test
+makes it impossible to add an entity kind that the conversion wiring silently cannot route.
+
+## Why this matters
+
+Five regex adapters and four preset adapters are registered, advertised in docs/FORMAT-SUPPORT.md,
+and fully exportable in the studio, yet the CLI refuses to convert them and blames "different
+entity kinds" for a same-kind request. Live proof at planning time (both exit 1):
+
+```
+hoplight convert src/formats/_fixtures/regex/marinara-essentials.json out.json --to sillytavern-regex
+  convert: cannot convert a regex to a regex (different entity kinds)
+hoplight convert samples/sillytavern/presets/plain.preset.json out.json --to rolecall-preset
+  convert: cannot convert a preset to a preset (different entity kinds)
+```
+
+## Proven root cause
+
+`src/convert.ts` `convertFile` (lines 136-161) enumerates same-kind branches for `character`,
+`lorebook`, and `persona` only, then falls through to the cross-kind throw for everything else,
+including same-kind regex and preset. Fact, not inference: the registry registers regex/preset
+adapters (see `src/formats/*/regex.ts`, `*/preset.ts`), and the studio's `handleExport`
+(`src/ui/server-engine.ts:172-177`) already performs the generic non-character export the CLI
+lacks. The kind union grew (adapter.ts added `RegexAdapter`, `PresetAdapter`) and this function was
+not updated; the persona branch shows the same copy-paste pattern that invites the omission.
+
+## Current architecture and authority
+
+- Canonical source of truth for conversions: `src/convert.ts` `convertFile`, called by
+  `src/cli.ts:363`. The studio does NOT use `convertFile` for export; it uses
+  `handleExport` in `src/ui/server-engine.ts`, whose generic branch is the proven exemplar:
+
+```ts
+// src/ui/server-engine.ts:172-177 (current)
+} else {
+  out = (target.fromCanonical as (e: AnyEntity) => {
+    bytes?: Uint8Array;
+    text?: string;
+    suggestedExtension: string;
+  })(entity);
+}
+```
+
+- Current convertFile same-kind branches (src/convert.ts:143-159) each do:
+  parse via `parseCanonicalEntity(src.toCanonical(input))`, assert kind, call
+  `target.fromCanonical`, wrap with `reportedOutput` (character path adds bundle context through
+  `emitBundle`).
+- Repository doctrines that bind this change: hub-and-spoke only; fail closed with honest
+  messages; red test first; kinds are a closed union discriminated on `kind`
+  (`src/core/adapter.ts:124-129`).
+
+## Target architecture
+
+One generic same-kind path with the character bundle special case. The invariant: for any two
+registered adapters `a`, `b` with `a.kind === b.kind`, `convertFile(a, b, input)` routes; for
+`a.kind !== b.kind` it throws the cross-kind message. Kind growth no longer touches this function.
+
+Exact replacement for the body of `convertFile` (src/convert.ts:136-161), keeping the existing
+signature and docblock intent (update the docblock's kind list sentence accordingly):
+
+```ts
+export function convertFile(
+  src: FormatAdapter,
+  target: FormatAdapter,
+  input: AdapterInput,
+  opts?: { requestedExtension?: string },
+): ConvertResult {
+  const req = opts?.requestedExtension;
+  if (src.kind !== target.kind) {
+    throw new Error(`convert: cannot convert a ${src.kind} to a ${target.kind} (different entity kinds)`);
+  }
+  if (src.kind === "character" && target.kind === "character") {
+    const { entity, lorebooks } = inspectBundle(src, input);
+    const out = emitBundle(target, entity, lorebooks, req);
+    return { out, lorebooks };
+  }
+  const parsed = parseCanonicalEntity(src.toCanonical(input));
+  if (parsed.kind !== src.kind) {
+    throw new Error(`convert: ${src.kind} adapter returned the wrong entity kind`);
+  }
+  // Same localized cast the studio export path uses (server-engine.ts): the kinds were proven
+  // equal above, but TS cannot correlate two union-typed values.
+  const out = (target.fromCanonical as (e: ParsedCanonicalEntity) => AdapterOutput)(parsed);
+  return { out: reportedOutput(target, parsed, out), lorebooks: [] };
+}
+```
+
+Notes that are load-bearing:
+
+- `ParsedCanonicalEntity` is already imported in convert.ts via `parseCanonicalEntity`; add the
+  type import if not present.
+- `requestedExtension` remains character-only (EmitContext), exactly as today for lorebook and
+  persona; the CLI's `assertContainerAgreement` (src/cli-io.ts) still guards container mismatches
+  downstream. Do not thread `req` into non-character adapters; their `fromCanonical` takes no
+  context by contract (src/core/adapter.ts:84-115).
+- This removes the lorebook and persona branches; their behavior is identical under the generic
+  path (same parse, same kind assert, same reportedOutput). Confirm by diffing test results, not
+  by reasoning alone.
+
+## Files
+
+### Modify
+- `src/convert.ts`: replace `convertFile` body as above; update its docblock kind sentence.
+- `src/convert.test.ts`: add the RED/GREEN cases and the registry sweep below.
+
+### Do not touch
+- `src/ui/server-engine.ts`: already correct; it is the exemplar, not a target.
+- `src/core/adapter.ts`, `src/core/registry.ts`: no contract change is needed.
+- Any `src/formats/**`: adapters are correct; this is wiring only.
+- `docs/FORMAT-SUPPORT.md`: regenerated content is owned by Plans 002/003.
+
+## API and compatibility
+
+CLI behavior change only: previously-failing same-kind invocations now succeed; the cross-kind
+error text is unchanged for genuinely cross-kind requests. `--json` report shape is unchanged
+(`reportedOutput` attaches the same `SerializeReport` the studio produces). Exit codes unchanged.
+
+## Implementation steps
+
+### Step 1: RED
+
+Add to `src/convert.test.ts` (exemplar style: src/m1.convert.smoke.test.ts, needCharacter helper
+pattern):
+
+1. regex: input `src/formats/_fixtures/regex/marinara-essentials.json` read as text, src adapter
+   the marinara regex member (id `marinara-regex`, declared `src/formats/marinara/index.ts:64`),
+   target `sillytavern-regex`; assert `convertFile` returns output with `report` and non-empty
+   `text`.
+2. preset: input `samples/sillytavern/presets/plain.preset.json`, src the sillytavern preset
+   adapter (id via `FORMAT_ID`, `src/formats/sillytavern/preset.ts:19`, used at `:25`), target
+   `rolecall-preset`; same assertions.
+3. registry sweep: after `loadFormats()`, for every registered adapter `a`, build a minimal
+   canonical entity of `a.kind` (reuse the minimal-entity literals in `src/core/registry.test.ts`
+   as the exemplar; add minimal regex/preset/persona/lorebook literals), emit
+   `a.fromCanonical(entity)`, feed the emitted text/bytes back as input, and assert
+   `convertFile(a, a, input)` does not throw. Skip an adapter only with an inline reason if its
+   emit is not re-readable standalone (record any such skip in the test output).
+
+Verify: `bun test src/convert.test.ts` -> the new regex and preset cases FAIL on current code with
+the exact message "convert: cannot convert a regex to a regex (different entity kinds)" (honest
+RED). If they fail any other way, STOP: the root-cause claim is wrong.
+
+### Step 2: GREEN
+
+Apply the `convertFile` replacement above. Do not modify the new tests.
+
+Verify: `bun test src/convert.test.ts` -> all new cases pass, prior cases unchanged.
+
+### Step 3: Live journey
+
+```
+bun run hoplight -- convert src/formats/_fixtures/regex/marinara-essentials.json /tmp/out-regex.json --to sillytavern-regex --yes
+bun run hoplight -- convert samples/sillytavern/presets/plain.preset.json /tmp/out-preset.json --to rolecall-preset --yes
+```
+
+Verify: both exit 0, print a report line, and the outputs re-detect:
+`bun run hoplight -- validate /tmp/out-regex.json` -> OK, kind regex;
+`bun run hoplight -- validate /tmp/out-preset.json` -> OK, kind preset.
+
+### Step 4: Broad checks
+
+Verify: `bun run typecheck` clean; `bun run test` -> no regressions from the 2250-pass baseline;
+`bun run test:m1` clean.
+
+Known interaction (GATE-01 / Plan 002): until Plan 002 lands, `bun run test` at this commit
+rewrites `docs/FORMAT-SUPPORT.md` (date-only) as an import side effect. After Step 4, run
+`git checkout -- docs/FORMAT-SUPPORT.md` to discard that unrelated churn before judging scope.
+If the diff on that file is anything MORE than the `Generated:` date line, STOP: something else
+changed the registry surface.
+
+## Test plan
+
+Covered in steps: honest RED on both live-proven failures; unchanged GREEN; registry-wide same-kind
+sweep as the recurrence firewall; existing m0/m1 suites as the regression net. New tests live in
+`src/convert.test.ts` (already in the `test` script's path list).
+
+## Documentation and operations
+
+`docs/reference/cli.md` describes convert generically and stays true after this change; step 4 of
+its checked-steps section mentions kinds only via convertFile, no edit required. If the executor
+finds any doc line claiming regex/preset CLI conversion is unsupported, update it in the same
+commit (none was found at planning time).
+
+## Done criteria
+
+- Both Step 3 commands exit 0 and their outputs validate.
+- `bun test src/convert.test.ts` includes the registry sweep and passes.
+- `bun run verify:ci` passes end to end.
+- `git diff --stat` touches only `src/convert.ts` and `src/convert.test.ts` (after discarding the
+  GATE-01 date-only side-effect diff on `docs/FORMAT-SUPPORT.md` per Step 4, if Plan 002 has not
+  landed yet).
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- The RED tests fail with any error other than the exact cross-kind message.
+- Any same-kind pair in the registry sweep fails under the generic path for a reason other than a
+  legitimately non-standalone emit (then: report, do not special-case silently).
+- The lorebook or persona behavior changes in any existing test.
+- Fixing this requires touching any file under `src/formats/`.
+
+## Rollback and recovery
+
+Single-commit revert; no data, schema, or storage contract is touched.
+
+## Maintenance notes
+
+- The registry sweep is the invariant keeper: a future `pack` (or any new) adapter kind gets CLI
+  conversion for free or fails the sweep loudly.
+- Reviewer trap: do not "improve" the localized cast into per-kind branches; the branches are the
+  defect class this plan removes.

--- a/audit-plans/002-make-the-format-matrix-gate-real.md
+++ b/audit-plans/002-make-the-format-matrix-gate-real.md
@@ -1,0 +1,195 @@
+# Plan 002: Make the format matrix gate real
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: P2
+- Category: tests/delivery
+- Effort: S
+- Risk: LOW
+- Depends on: none
+- Planned at: commit `80451e6`, 2026-07-24
+- Finding: GATE-01 in AUDIT.md
+
+## Outcome
+
+`bun test` never writes to the working tree; `matrix:check` genuinely fails CI when the committed
+`docs/FORMAT-SUPPORT.md` is stale against the adapter registry; `bun run matrix` remains the one
+way the file is written.
+
+## Why this matters
+
+Today the matrix gate is decorative. `scripts/format-matrix.ts` runs its whole main flow at module
+scope; `scripts/format-matrix.test.ts:7` imports it; the `test` script includes `scripts/`, so
+every `bun test` run regenerates `docs/FORMAT-SUPPORT.md` from the live registry with today's
+date. In `verify:ci`, `test` runs before `matrix:check` (package.json), so the check always
+compares a just-regenerated file against another fresh regeneration: it cannot fail, and a stale
+committed matrix ships with CI green. Side effect two: every developer test run dirties the tree
+(live-proven this session; the audit worktree carried exactly this date-only diff).
+
+## Proven root cause
+
+`scripts/format-matrix.ts`:
+
+- line 11: `const checkOnly = process.argv.includes("--check");` reads bun test's argv, so
+  `checkOnly` is false under the test runner;
+- line 13: `const found = await loadFormats();` runs at import;
+- lines 102-128: entity-kind readdir, render with `new Date()`, then either the check branch or,
+  when `checkOnly` is false (the test-import case), line 127 `writeFileSync(outPath, body)`.
+
+The test imports only the pure exports `matrixKinds` and `renderFormatMatrix`, but importing the
+module executes everything above.
+
+## Current architecture and authority
+
+- The generator is both a CLI entry point (package.json scripts `matrix`, `matrix:check`) and a
+  library for its test. The sibling hook scripts already model the fix: pre-commit logic lives in
+  pure `scripts/hooks/pre-commit-core.ts` imported by its test, with the impure runner separate.
+- `verify:ci` order (package.json): `... bun run test && ... && bun run matrix:check && ...`.
+  The order itself is fine once the side effect is gone; do not reorder.
+
+## Target architecture
+
+`scripts/format-matrix.ts` keeps its pure exports at module scope and moves every side effect
+behind an entry guard. Invariant: importing the module performs no I/O.
+
+Exact shape (replace lines 10-13 and 102-128; keep `matrixKinds` and `renderFormatMatrix`
+unchanged in between):
+
+```ts
+const outPath = join(import.meta.dir, "../docs/FORMAT-SUPPORT.md");
+
+// (matrixKinds, KIND_TITLES, KIND_ORDER, renderFormatMatrix stay in place, but BOTH
+// module-scope helpers currently typed off `typeof found` must be retyped, because
+// `found` moves inside main(): the `row` helper at scripts/format-matrix.ts:15-16
+// (`(a: (typeof found)[number])`) and renderFormatMatrix's `adapters: typeof found`
+// parameter. Use the explicit adapter shape they actually consume, e.g.
+// `FormatAdapter` / `FormatAdapter[]` imported as a type from ../src/core.)
+
+async function main(): Promise<void> {
+  const checkOnly = process.argv.includes("--check");
+  const found = await loadFormats();
+  const entityKinds = readdirSync(join(import.meta.dir, "../src/entities"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  const body = renderFormatMatrix(found, CANONICAL_SCHEMA_VERSION, new Date().toISOString().slice(0, 10), entityKinds);
+
+  if (checkOnly) {
+    // (existing check branch, lines 108-124, unchanged including date normalization)
+    return;
+  }
+  writeFileSync(outPath, body, "utf8");
+  console.log(`wrote ${outPath} (${found.length} adapters)`);
+}
+
+if (import.meta.main) await main();
+```
+
+Also delete the leftover thinking-aloud comment at lines 116-117 ("Actually plan wants...") while
+that block moves; keep the date-normalization behavior itself exactly as is.
+
+Why this removes the cause: the test import no longer executes `main()`, so `bun test` writes
+nothing; in CI the file `matrix:check` reads is the committed one, so staleness fails honestly.
+
+## Files
+
+### Modify
+- `scripts/format-matrix.ts`: entry-guard restructure above; type the render params explicitly.
+- `scripts/format-matrix.test.ts`: add the no-side-effect regression test below.
+
+### Do not touch
+- `package.json` scripts (`matrix`, `matrix:check`, `verify:ci` order all remain correct).
+- `docs/FORMAT-SUPPORT.md` content (Plan 003 owns the template fix and regeneration).
+- Other generator scripts (`docs-index`, `docs-fields`, `docs-figures`): out of scope. They have
+  no tests of their own, so nothing imports them under `bun test`; `scripts/` contains exactly one
+  test that imports a side-effectful generator (format-matrix.test.ts), and the four
+  `scripts/hooks/*.test.ts` files import only pure `-core`/`-lib` modules (verified at planning
+  time).
+
+## Implementation steps
+
+### Step 1: RED
+
+Add to `scripts/format-matrix.test.ts` a subprocess-based no-write assertion:
+
+```ts
+test("importing the generator module performs no write", () => {
+  const before = statSync(new URL("../docs/FORMAT-SUPPORT.md", import.meta.url)).mtimeMs;
+  const r = Bun.spawnSync(["bun", "-e", 'await import("./scripts/format-matrix.ts"); '], {
+    cwd: new URL("..", import.meta.url).pathname,
+  });
+  expect(r.exitCode).toBe(0);
+  const after = statSync(new URL("../docs/FORMAT-SUPPORT.md", import.meta.url)).mtimeMs;
+  expect(after).toBe(before);
+});
+```
+
+Verify: `bun test scripts/format-matrix.test.ts` -> the new test FAILS on current code (mtime
+changes). Honest RED.
+
+### Step 2: GREEN
+
+Apply the restructure. Do not weaken the new test.
+
+Verify: `bun test scripts/format-matrix.test.ts` -> all pass, including the two existing pure
+tests (they must not need edits; if they do, STOP: the pure surface changed).
+
+### Step 3: Prove the gate now bites
+
+In the worktree (revert afterwards, no commit):
+
+1. `bun run matrix` then `git diff docs/FORMAT-SUPPORT.md` -> date-only or empty diff; restore.
+2. Hand-edit one row of `docs/FORMAT-SUPPORT.md` (e.g. delete an adapter line).
+3. `bun run test` -> tree still shows ONLY your hand edit (no rewrite).
+4. `bun run matrix:check` -> exits 1 with the stale message.
+5. `git checkout -- docs/FORMAT-SUPPORT.md`.
+
+### Step 4: Broad checks
+
+Verify: `bun run typecheck`; `bun run test` (baseline 2250 pass) and afterwards
+`git status --porcelain` shows no generated churn; `bun run verify:ci` passes.
+
+## Test plan
+
+Steps 1-2 are the focused RED/GREEN. Step 3 is the live journey for the gate itself. The existing
+`matrixKinds`/`renderFormatMatrix` tests are the regression net for the pure surface.
+
+## Documentation and operations
+
+`docs/FORMAT-SUPPORT.md`'s header line "Auto-generated from live adapters (`bun run
+scripts/format-matrix.ts`)" stays true. No reference page documents the import side effect
+(nothing to update). AGENTS.md's gate table line for `matrix:check` becomes true instead of
+aspirational; its wording needs no change.
+
+## Done criteria
+
+- Step 3 sequence behaves exactly as specified (hand-staled file fails matrix:check after a full
+  test run).
+- `bun run test` leaves `git status --porcelain` empty on a clean checkout.
+- `bun run verify:ci` passes.
+- Diff touches only `scripts/format-matrix.ts` and `scripts/format-matrix.test.ts`.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- The existing pure tests require edits to survive the restructure.
+- Any other test in the suite turns out to depend on the import-time write (search first:
+  `grep -rn "FORMAT-SUPPORT" src scripts` shows only the generator, its test, and prose corpus
+  references at planning time).
+- `verify:ci` fails at matrix:check after the change on an honest tree: that means the committed
+  matrix was ALREADY stale and masked; regenerate via `bun run matrix`, commit that separately,
+  and say so in the report.
+
+## Rollback and recovery
+
+Single-commit revert restores the old (defective but familiar) behavior; no data or release risk.
+
+## Maintenance notes
+
+- Invariant for future generators: a script that a test imports must be side-effect-free at import
+  (entry-guard or split a `-core` module, as the hooks already do).
+- Reviewer trap: do not "fix" this by excluding `scripts/` from the test script; that would delete
+  real coverage to hide the symptom.

--- a/audit-plans/003-align-front-door-docs-with-the-built-product.md
+++ b/audit-plans/003-align-front-door-docs-with-the-built-product.md
@@ -1,0 +1,213 @@
+# Plan 003: Align the front-door docs with the built product
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: P3
+- Category: docs/DX
+- Effort: S
+- Risk: LOW
+- Depends on: none (soft: run 002 first so the regenerated matrix lands behind an honest gate)
+- Planned at: commit `80451e6`, 2026-07-24 (rewritten same day after adversarial review widened
+  the defect class)
+- Finding: DOCS-01 in AUDIT.md
+
+## Outcome
+
+No committed doc aimed at a runnable-now audience instructs a `vaud <command>` invocation: not the
+generated format matrix, not the docs front door, not the shipped-milestone lines of the roadmap.
+The planning-vs-reference boundary that docs/README.md already draws is propagated to AGENTS.md
+and to the planning docs themselves, and docs/README.md stops contradicting it in its own words.
+`specs/**` and the ADRs deliberately keep their design-era `vaud` vocabulary.
+
+## Why this matters
+
+The shipped CLI is `hoplight` (package.json `bin`; script `hoplight`). Yet, live-proven at
+planning time, `bun run vaud formats` fails with `error: Script not found "vaud"`, and these
+runnable-now surfaces still teach `vaud`:
+
+- `docs/FORMAT-SUPPORT.md:10-13` (usage block) and `:80` ("Prefer `vaud label`"), both generated
+  from `scripts/format-matrix.ts:66-71` and `:80`.
+- `docs/README.md:12-13`: "Its engine and CLI are called vaud"; `docs/README.md:39`: reference
+  row for ui.md says "`vaud ui`, the local server".
+- `docs/ROADMAP.md:81-82`: the SHIPPED M1 exit criteria named as `vaud convert / inspect /
+  validate / import --bundle / export --all-formats` and `vaud upgrade`.
+
+And the planning boundary leaks: docs/README.md:50-53 correctly labels 01/02/03 "the founding
+planning docs" and points at reference/architecture.md as the as-built truth, but AGENTS.md's
+required-reading table (section 1, rows 1-3) still presents 02/03 as current contract with no
+such caveat, the planning docs themselves carry no banner, and the same docs/README.md sentence
+calls 03-CONVENTIONS "the binding code and process conventions", making 03 simultaneously
+history and law.
+
+Minor same-family defect: built-in help (`src/cli.ts:126-131`) omits `--strict` from Options
+while the usage strings and docs/reference/cli.md:50 document it.
+
+## Proven root cause
+
+The 01/02/03 documents and the roadmap predate the rename to `hoplight` (02's own heading says
+"the future `vaudeville-studios` code repo"); docs/README.md was written with the planning label
+but not swept for its own `vaud` claims; the matrix generator template was never renamed. Fact
+throughout, no inference.
+
+## Current architecture and authority
+
+- Truth-based reference docs: `docs/reference/**`. Docs front door: `docs/README.md`.
+- Planning docs: `docs/01-VISION.md`, `docs/02-ARCHITECTURE.md`, `docs/03-CONVENTIONS.md`.
+- Command-name authority: package.json (`bin: { hoplight: ./src/cli.ts }`, script `hoplight`)
+  and docs/reference/cli.md's Invocation section. (A CLAUDE.md exists only as an untracked local
+  file; it is NOT citable authority for an executor.)
+- Doc gates: `scan:links`, `scan:emdash`, `docs:index:check` (pre-commit regenerates the index
+  from the staged snapshot), `matrix:check`.
+- Deliberate non-goals: `specs/**` keeps `vaud` as its internal design vocabulary (100+ sites,
+  consistent, milestone contracts; renaming is a maintainer taste decision surfaced in the PR,
+  not this plan); `docs/decisions/ADR-003` keeps its decision-era wording (ADRs are history);
+  engine docblocks mentioning `vaud convert` (src/formats/{agnai,risu,novelai}/lorebook.ts:2)
+  are internal comments, out of scope.
+
+## Target architecture
+
+Label history, fix runnable-now surfaces, keep still-binding law binding.
+
+1. `scripts/format-matrix.ts:66-71`: replace the four usage lines with the working forms:
+
+```
+bun run hoplight -- formats
+bun run hoplight -- inspect path/to/card.png
+bun run hoplight -- convert in.png out.json --to sillytavern
+bun run hoplight -- validate path/to/card.json
+```
+
+   `scripts/format-matrix.ts:80`: change "Prefer \`vaud label\` when unsure." to
+   "Prefer \`bun run hoplight -- label\` when unsure." Then `bun run matrix` and commit the
+   regenerated `docs/FORMAT-SUPPORT.md`.
+
+2. `docs/README.md:12-13`: reword to name the product truthfully, e.g. "Its CLI is `hoplight`
+   (the engine's historical working name was vaud, which `specs/` still uses)". `docs/README.md:39`:
+   "`vaud ui`" becomes "`hoplight ui`". `docs/README.md:50-53`: keep the founding-planning-docs
+   sentence, but split 03's description so law and history separate, e.g. "...and
+   `03-CONVENTIONS.md` carries the code and process conventions; its testing and code law remain
+   binding, while its planning-era names (`vaud`, `fixtures/`, `packages/`) are historical, see
+   each file's status note."
+
+3. `docs/02-ARCHITECTURE.md`: after the H1, add:
+
+```markdown
+> **Status: planning-era document.** This page records the original product plan and its
+> vocabulary (`vaudeville-studios`, `packages/*`, the `vaud` CLI). The repo you are in is the
+> built product; the live map is [reference/architecture.md](reference/architecture.md). Where
+> this page and the reference docs disagree, the reference docs win.
+```
+
+4. `docs/03-CONVENTIONS.md`: after the H1, add a NARROWER note (03 is not demoted; its law
+   remains in force):
+
+```markdown
+> **Status note.** The conventions here remain binding and are enforced by the gates listed in
+> [AGENTS.md](../AGENTS.md) section 4. Names from the planning era are historical: the CLI is
+> `hoplight` (not `vaud`), the sample corpus lives in `samples/` plus per-format fixture folders
+> (not `fixtures/<format>/<case>/`), and the repo is laid out per
+> [reference/architecture.md](reference/architecture.md) (not `packages/*`).
+```
+
+5. `AGENTS.md` section 1 table: reword the "Why it's required" cells for rows 1-3 to carry the
+   same split (vision and planning context; naming historical; reference docs win on conflict).
+   Do NOT claim AGENTS.md restates the testing law; it does not. The deterministic-test law's
+   home remains 03-CONVENTIONS, kept binding by item 4's note.
+
+6. `src/cli.ts` HELP Options block: add one `--strict` line beside `--yes`, copy matching
+   docs/reference/cli.md ("convert: refuse to write when any field would be dropped").
+
+## Files
+
+### Modify
+- `scripts/format-matrix.ts`: usage block lines 66-71 AND Notes line 80.
+- `docs/FORMAT-SUPPORT.md`: regenerated output only (never hand-edited).
+- `docs/README.md`: lines 12-13, 39, 50-53 as specified.
+- `docs/ROADMAP.md`: in the M1 (shipped) lines 81-82, rename the command names to `hoplight`
+  forms; leave future-milestone `vaud upgrade` mentions (94, 194) for the maintainer to decide
+  with specs vocabulary, and say so in the PR.
+- `docs/02-ARCHITECTURE.md`, `docs/03-CONVENTIONS.md`: status notes (items 3-4).
+- `AGENTS.md`: three table cells (item 5).
+- `src/cli.ts`: one HELP line (item 6).
+
+### Do not touch
+- `docs/01-VISION.md`: no wrong commands or paths; aspirational by nature.
+- `specs/**`, `docs/decisions/**`: design-era vocabulary is deliberate; surfaced in the PR as a
+  question, never bulk-edited here.
+- `docs/reference/**` except regenerated FORMAT-SUPPORT.md.
+
+## Implementation steps
+
+### Step 1: Generator template (both sites)
+
+Edit `scripts/format-matrix.ts:66-71` and `:80`. Verify:
+`bun run matrix && grep -cE "\bvaud " docs/FORMAT-SUPPORT.md` -> `0`, and
+`bun run hoplight -- formats` plus `bun run hoplight -- label samples/sillytavern/characters/v3-full.json`
+both exit 0 as pasted (label path proves the Notes line's replacement is real).
+
+### Step 2: docs front door and roadmap
+
+Apply items 2 and the ROADMAP M1 renames. Verify: `grep -nE "\bvaud (convert|inspect|validate|label|ui|upgrade|formats|import|export)\b" docs/README.md` -> no hits;
+same grep on `docs/ROADMAP.md` -> hits only on the future-milestone lines deliberately left
+(list them in the PR).
+
+### Step 3: Status notes and AGENTS.md cells
+
+Apply items 3-5. Verify: `bun run scan:links` clean; `bun run scan:emdash` clean.
+
+### Step 4: HELP --strict
+
+Apply item 6. Verify: `bun run hoplight -- help | grep -- --strict` -> one line.
+
+### Step 5: Broad checks
+
+Verify: `bun run verify:ci` end to end. Class check (the done criterion, not just the first-found
+instance): `grep -rnE "\bvaud (convert|inspect|validate|label|ui|upgrade|formats|import|export)\b" docs/ README.md AGENTS.md CONTRIBUTING.md scripts/`
+returns hits ONLY in `docs/02-ARCHITECTURE.md` (status-noted), `docs/decisions/` (history), and
+the deliberately-left ROADMAP future lines.
+
+## Test plan
+
+Docs plus one help string; the gates and the greps in each step are the tests. No unit test is
+warranted for a help string; state that in the PR rather than manufacturing one.
+
+## Documentation and operations
+
+This plan IS the documentation change. Release note: put `[skip release]` in the squash/merge
+commit message itself if maintainers do not want a patch release (per CONTRIBUTING.md the train
+reads only the landing commit).
+
+## Done criteria
+
+- Step 5's class grep returns only the named allowed locations.
+- All four matrix usage commands and the label command run as pasted from repo root (exit 0).
+- 02 and 03 open with their status notes; docs/README.md carries no `vaud` command claims and no
+  longer calls 03 binding-without-qualification; AGENTS.md cells updated.
+- `bun run hoplight -- help` lists `--strict`.
+- `bun run verify:ci` passes.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- Maintainer signal that the `vaud` name is intended to STAY user-facing (then this plan inverts:
+  the bug would be in package.json's `bin`, and that is a product decision, not a docs sweep).
+- The Step 5 class grep surfaces runnable-now sites beyond the files this plan names: widen the
+  file list in this plan (same PR) or report; never leave a known instance silently.
+- Plan 002 not landed AND the regenerated matrix diff contains anything beyond the usage block,
+  the Notes line, and the date: reconcile against Plan 002 first.
+
+## Rollback and recovery
+
+Docs and one string: revert the commit. The regenerated matrix reverts with it.
+
+## Maintenance notes
+
+- Future planning documents get a status note from day one.
+- The specs/ vocabulary question (rename `vaud` to `hoplight` across design contracts, or keep as
+  internal codename) is explicitly handed to the maintainer in the PR; do not let a future sweep
+  bulk-edit specs without that decision.
+- Reviewer trap: do not hand-edit `docs/FORMAT-SUPPORT.md`; only the generator writes it.

--- a/audit-plans/004-surface-damaged-entities-in-the-library.md
+++ b/audit-plans/004-surface-damaged-entities-in-the-library.md
@@ -1,0 +1,208 @@
+# Plan 004: Surface damaged entities in the library
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: P4
+- Category: UX/data
+- Effort: M
+- Risk: LOW-MEDIUM (touches the store contract and its OPFS twin)
+- Depends on: none
+- Planned at: commit `80451e6`, 2026-07-24 (revised same day after adversarial review)
+- Finding: UX-01 in AUDIT.md
+
+## Outcome
+
+A studio entity file that exists on disk but cannot be read (corrupt JSON, schema rejection, kind
+or id mismatch) is visible in the library as a damaged item with its filename and a plain-language
+reason, instead of silently disappearing. Healthy entities keep rendering exactly as today.
+
+## Why this matters
+
+Hoplight's pillar is local-first: the files are the user's. Today `StudioStore.list()` swallows
+every per-file failure (`src/studio/store.ts:111-113` `catch { continue; }`), `read()` collapses
+all causes into `StudioReadError("corrupt entity file")` (store.ts:124-146), and the character
+schema requires all eight body groups (`src/entities/runtime-schema.ts:37-102`), so a hand-edited
+or partially synced file fails whole-cloth. The user sees their card missing with no signal that
+the bytes still exist and are recoverable. Doctrine says storage and validation failures are
+reported honestly; fail closed must not mean fail invisibly.
+
+## Proven root cause
+
+Code-read, mechanism certain: the skip happens in `list()` at store.ts:111-113 (read failures) and
+at store.ts:89-93 (ids failing `assertSafeStudioId` are skipped by design; `.tmp-*` orphans land
+here and MUST stay hidden). Nothing upstream (`/api/studio/list`, `src/ui/server.ts:326-332`) or
+downstream (library app) ever learns a file was skipped.
+
+## Current architecture and authority
+
+- Authority for listings: `StudioStore.list(kind?)` returning `EntitySummary[]`
+  (src/studio/store.ts:23-32, 78-117).
+- Contract consumed through `StudioStoreLike` (`src/studio/contracts.ts`) by the server routes and
+  by the OPFS pocket twin (`src/studio/opfs/`, P1c work "the OPFS StudioFs twin"). The twin shares
+  `StudioStore` over a different `StudioFs` backend, so changes to `list()` itself cover both; the
+  contract file changes only if the method signature grows.
+- UI: `/api/studio/list` -> library app (`src/ui/apps/library/index.tsx`, views under
+  `src/ui/apps/library/views/`).
+- Reuse rule: shared controls come from `docs/reference/components.md`; the catalog has no
+  generic notice component, and apps (Settings) hand-roll local notice classes, so app-local is
+  the established pattern here.
+
+## Target architecture
+
+New invariant: `list()` accounts for every `.json` file in a kind directory: each becomes either a
+summary or a damage record. Additive API, no breaking change:
+
+- `src/studio/store.ts`: add
+
+```ts
+export interface DamagedEntry {
+  kind: string;
+  /** filename stem; the file is <kind>/<id>.json */
+  id: string;
+  /** stable, user-safe cause */
+  reason: "unreadable-json" | "schema-mismatch" | "kind-mismatch" | "id-mismatch";
+}
+```
+
+  `list()` keeps its signature and behavior. Add a sibling
+  `listDamaged(kind?: string): Promise<DamagedEntry[]>` that walks the same directories and
+  classifies failures. To avoid double-reading in the common healthy case, extract the per-file
+  read-and-classify into a private helper both methods share; `read()` itself must distinguish the
+  four causes internally (today it throws one opaque message for all; widen `StudioReadError` with
+  an optional `cause` field rather than new error classes). Public `read()` behavior for callers
+  is unchanged.
+- `src/studio/contracts.ts`: add `listDamaged` to `StudioStoreLike`.
+- `src/ui/server.ts`: `/api/studio/list` response stays `EntitySummary[]`; add
+  `/api/studio/damaged?kind=` returning `DamagedEntry[]` beside it (same auth path as list; it is
+  already inside the /api gate).
+- Library app: on shelf load, fetch damaged alongside list; when non-empty, render one notice
+  band reading "N file(s) in your studio folder could not be read", expandable to filename +
+  reason + the studio folder path already exposed by `/api/version` (`studioDir`). Component
+  reality check (corrected after adversarial review): the shared catalog has NO generic
+  notice/banner component; the only cataloged notice (`WorkshopNotice`,
+  docs/reference/components.md, src/ui/apps/workbench/workshop/notice.tsx) is workbench-local,
+  and Settings hand-rolls local classes (`warnNote` in
+  src/ui/apps/settings/sections/updates-dialogs.tsx, `statusNote` in about.tsx). Follow that
+  established app-local pattern: build the band as a small element inside the library app with
+  its own CSS-module classes on theme tokens. Do NOT add a folder under src/ui/components/
+  (catalog:check stays untouched) and do NOT import another app's notice across app boundaries.
+  No repair actions in this plan; visibility only.
+- `.tmp-*` and other unsafe-id files stay excluded (they are not user entities); only files whose
+  id passes `assertSafeStudioId` but whose CONTENT fails become damage records.
+
+## Files
+
+### Modify
+- `src/studio/store.ts`: `DamagedEntry`, `listDamaged`, shared read-classify helper, widened
+  `StudioReadError` cause.
+- `src/studio/errors.ts`: optional `cause` on `StudioReadError` (constructor default keeps the
+  current message; existing `isStudioReadError` untouched).
+- `src/studio/contracts.ts`: `listDamaged` on `StudioStoreLike`.
+- `src/ui/server.ts`: the `/api/studio/damaged` route.
+- `src/ui/apps/library/index.tsx` (and the view module the executor finds owns the shelf header):
+  the notice band.
+- `src/studio/store.test.ts` and `src/ui/server.test.ts`: coverage below.
+
+### Do not touch
+- `src/entities/runtime-schema.ts`: loosening the schema is NOT this plan; strictness is the
+  parse-don't-validate boundary working as designed.
+- `src/studio/atomic-file.ts`, save paths, delete paths.
+- Any format adapter.
+
+## API and compatibility
+
+New endpoint only; existing `/api/studio/list` byte-identical for healthy studios. The OPFS twin
+gains `listDamaged` through the shared class; if the twin overrides `list`-adjacent behavior in
+its own file, mirror the classification there (executor: check `src/studio/opfs/` before coding;
+at planning time the twin injects a `StudioFs` backend and reuses `StudioStore`, so no twin edit
+is expected).
+
+## UI and user journey
+
+Entry: open Library with a damaged file present. State: notice band above the shelf, count plus
+expandable rows (filename, reason text, studio folder path). Empty state: band absent. Recovery
+guidance copy: "The file is still on disk; it was not changed. Restore it from a backup or remove
+it to clear this notice." Accessibility: the band is a semantic region with a heading, keyboard
+expandable, theme tokens only (no hardcoded colors). Refresh: band recomputes on every shelf
+load; no client cache.
+
+## Implementation steps
+
+### Step 1: RED (store)
+
+In `src/studio/store.test.ts` (follow that file's existing exemplar: real temp dirs via mkdtemp;
+the fake handle tree lives only in src/studio/opfs/fs.test.ts if an in-memory variant is ever
+needed): seed a kind dir with one healthy entity, one truncated JSON file,
+one schema-failing file (drop the `examples` group), one kind-mismatched file. Assert:
+`list()` returns exactly the healthy one (current behavior, must stay green) and
+`listDamaged()` returns the three with reasons `unreadable-json`, `schema-mismatch`,
+`kind-mismatch`. The `listDamaged` assertions FAIL now (method absent): honest RED.
+
+### Step 2: GREEN (store)
+
+Implement per target architecture. Verify: `bun test src/studio` -> new tests pass, all existing
+store tests untouched and green.
+
+### Step 3: Route
+
+Add `/api/studio/damaged`; test in `src/ui/server.test.ts` beside the existing `/api/studio/list`
+tests (same auth fixture): healthy-only studio returns `[]`; seeded-damage studio returns the
+records; the route refuses the same unauthenticated requests list refuses (copy the existing
+list-route negative test).
+
+### Step 4: Library band
+
+Implement the app-local band per the target architecture (library-owned markup + CSS-module
+classes on theme tokens; no shared component). Live journey (mandatory, per repo law UI is
+live-proven): `bun run dev`, drop a truncated `.json` into the studio character folder, reload
+Library, see the band with count 1 and the filename; remove the file, reload, band gone. Record
+both observations in the PR.
+
+### Step 5: Broad checks
+
+`bun run typecheck`; `bun run test`; `bun run lint:ui`; `bun run catalog:check` (must be clean:
+no new component folder was added); full `bun run verify:ci`.
+
+## Test plan
+
+Steps 1-4 name every case. Regression net: full store suite, server suite, library UI tests.
+Assertion quality rule: the damaged-reason assertions must match exact reason strings, not just
+array length.
+
+## Documentation and operations
+
+Update `docs/reference/ui.md` Library section (truth-based: describe the band and when it shows)
+and `docs/reference/entities/` storage page if it documents list behavior, in the same commit.
+
+## Done criteria
+
+- Step 4 live journey observed and reported with both states.
+- A studio with zero damage renders byte-identical list responses (server test asserts `[]` and
+  the band absent).
+- `bun run verify:ci` passes.
+- No new component folder; catalog:check green.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- The OPFS twin turns out to reimplement `list()` separately: stop and extend the plan to cover it
+  explicitly rather than shipping a desktop-only truth.
+- The band turns out to need a shared component after all (a second app wants it): report;
+  promoting app-local UI into the shared catalog is its own reviewed change, out of scope here.
+- Any existing store/server test needs weakening.
+
+## Rollback and recovery
+
+Additive endpoint and UI band: single revert. No stored data is written or migrated; damaged files
+are never modified, moved, or deleted by this feature.
+
+## Maintenance notes
+
+- Future schema-version bumps make `schema-mismatch` the common reason; the band is the user-facing
+  tripwire for that day (pairs with the switch system's storage-shape tripwire).
+- Reviewer trap: resist auto-repair or auto-quarantine here; visibility first, mutation never
+  (this plan), repair as its own reviewed feature if ever.

--- a/audit-plans/AUDIT.md
+++ b/audit-plans/AUDIT.md
@@ -1,0 +1,306 @@
+# Hoplight Systemic Audit
+
+- Mode: audit standard, direct (conductor-only, no shards, per operator instruction)
+- Focus: all playbook categories EXCEPT security and privacy (explicitly excluded by the operator)
+- Commit: `80451e6` (Mainstage, v0.1.13), audited 2026-07-24
+- Auditor: Claude Fable 5 (benchmark session, branch `audit/grumpy-fable-5`)
+- Working tree note: `docs/FORMAT-SUPPORT.md` was already dirty (date-only regeneration) before this
+  audit began and is left untouched. The cause of that dirt is itself Finding GATE-01.
+
+## Verification baseline
+
+Run in this worktree before any judgment, commands taken from AGENTS.md (never guessed):
+
+| Command | Result |
+| --- | --- |
+| `bun run typecheck` | clean, exit 0 |
+| `bun run test` | 2250 pass, 1 skip, 0 fail, 239 files, 5.28s |
+
+The full wall is `bun run verify:ci`. Note that `bun run test` itself rewrote
+`docs/FORMAT-SUPPORT.md` during the baseline run; see GATE-01.
+
+## Authoritative instructions read
+
+AGENTS.md (binding contract), CONTRIBUTING.md, docs/README.md, docs/01-VISION.md,
+docs/02-ARCHITECTURE.md, docs/03-CONVENTIONS.md, docs/reference/architecture.md,
+docs/reference/cli.md, ADR-001..ADR-009, package.json scripts, .github/workflows (ci,
+auto-release), .githooks + scripts/hooks/pre-commit.ts. A CLAUDE.md exists in the primary local
+checkout but is untracked (absent at `80451e6`); nothing below relies on it as repo authority.
+
+Settled decisions honored as by-design (not reported as defects): hub-and-spoke only; escrow
+immutability; sealed scripts (ADR-009); folders-as-schema; AGPL (ADR-002); single-exe distribution
+(ADR-003); React 19 shell (ADR-008 supersedes ADR-007's vanilla stance); Mainstage-as-release-branch
+with `[skip release]` escape; the packaged switch engine deliberately staging rather than
+self-swapping the running exe.
+
+## Audited surfaces
+
+- Core engine: `src/core/canonical.ts`, `adapter.ts`, `registry.ts`, `loader.ts`, `src/convert.ts`,
+  `src/entities/runtime-schema.ts` (full reads).
+- Studio storage: `src/studio/store.ts`, `atomic-file.ts`, `bundle.ts`, `portrait.ts` (full reads);
+  path-policy and fs-backend skimmed.
+- UI server: `src/ui/server.ts`, `server-engine.ts` (full reads); switch system
+  (`src/ui/switch/*`: manager, routes, packaged-engine, source-engine, git-runner) as the
+  highest-churn recent surface.
+- CLI: `src/cli.ts`, cli reference doc.
+- Lore engine: `src/core/lore/activation.ts` loop bounds and recursion caps (spot check; the module
+  carries its own dense test suite).
+- Delivery: CI workflows, release train, pre-commit orchestration, gate scripts
+  (`scripts/format-matrix.ts` and test, prose-guards scope, docs-index staging logic).
+- Tests: suite composition, m0/m1 smoke scope, detection firewall tests, live garbage-input probe of
+  all 28 registered detectors.
+- Live reproductions run: regex and preset CLI conversions (fail), `bun run vaud formats` (fails),
+  garbage-to-detectors probe (clean), synthetic 40-entity heavyweight library timing.
+
+## Omitted surfaces (explicit)
+
+- Security and privacy categories: excluded by operator instruction. Server auth gates, CSP, path
+  containment, sandbox origin, and remote-access trust logic were read only as far as needed for
+  correctness context; no security findings are reported and none should be inferred from silence.
+- Per-adapter escrow field mapping in the nine format folders: relied on the fixture-backed
+  Round-Trip Law suite (CI-blocking) plus structural reads; individual field mappings were not
+  re-derived from platform specs.
+- The React UI component tree and visual behavior: not live-driven this session (the repo's own
+  `bun run audit:*` UI harness needs a browser session). UX findings below are code-read and marked
+  as such.
+- The OPFS pocket-build twin (`src/studio/opfs/`): read for contract shape only.
+- `specs/` for future milestones: treated as design intent, not audited as code.
+
+## Evidence standards
+
+Every finding cites file:line at commit `80451e6` and was verified by opening the cited source.
+Labels: live-proven (reproduced by running it), unit-proven (existing/observed test behavior), or
+code-read. Severity reflects user or maintainer harm at this repo's actual scale, not theory.
+
+## Findings
+
+| ID | Severity | Category | Title | Proof | Plan |
+| --- | --- | --- | --- | --- | --- |
+| CORR-01 | HIGH | correctness | CLI cannot convert regex or preset files; error message is false | live-proven | 001 |
+| GATE-01 | MEDIUM | tests/delivery | `bun test` rewrites FORMAT-SUPPORT.md, so the matrix gate can never fail in CI | live-proven | 002 |
+| DOCS-01 | MEDIUM | docs/DX | Front-door docs describe a product that does not exist; generated doc's commands fail | live-proven | 003 |
+| UX-01 | MEDIUM | UX/data | Damaged entity files silently vanish from the library | code-read | 004 |
+| TEST-01 | MEDIUM | tests | No conversion-wiring coverage for non-character kinds | code-read | folded into 001 |
+| PERF-01 | LOW | performance | Library list and portrait serving re-parse full entity JSON including base64 carriers | measured | recorded, no plan |
+
+### [CORR-01] Restore regex and preset conversion through the CLI
+
+- Severity: HIGH
+- Evidence:
+  - `src/convert.ts:136-161` `convertFile`: same-kind branches exist for `character` (143),
+    `lorebook` (148), `persona` (154) only; everything else falls to line 160's
+    "different entity kinds" throw.
+  - Registry at HEAD registers 5 regex adapters and 4 preset adapters (sillytavern, rolecall, risu,
+    marinara, lumiverse regex; sillytavern, rolecall, marinara, lumiverse preset).
+  - `src/ui/server-engine.ts:172-177` `handleExport`: the studio path handles every non-character
+    kind through a generic `target.fromCanonical(entity)` call, so the engine itself supports these
+    conversions; only the CLI wiring never grew.
+  - `docs/FORMAT-SUPPORT.md` advertises the regex and preset adapters with a "writes" column.
+- Mechanism: `hoplight convert` routes everything through `convertFile` (`src/cli.ts:363`).
+  A regex-to-regex or preset-to-preset conversion is same-kind, but no branch matches, so the
+  cross-kind error fires with a self-contradictory message.
+- Live proof (this session, exit 1 both times):
+  - `hoplight convert src/formats/_fixtures/regex/marinara-essentials.json out.json --to sillytavern-regex`
+    prints "convert: cannot convert a regex to a regex (different entity kinds)".
+  - `hoplight convert samples/sillytavern/presets/plain.preset.json out.json --to rolecall-preset`
+    prints "convert: cannot convert a preset to a preset (different entity kinds)".
+- Impact: two of five entity kinds are unconvertible from the CLI while the format matrix and CLI
+  docs advertise them; the error actively misinforms the user about the cause.
+- Systemic boundary: `convertFile`'s per-kind enumeration. Adding an entity kind requires
+  remembering to edit this function; that has now been forgotten twice (preset and regex). The
+  repair is one generic same-kind path (the shape `handleExport` already proves), not two more
+  copy-paste branches.
+- Duplicate manifestations: the false error text; matrix advertising; TEST-01.
+- Effort: S-M. Fix risk: LOW (mirrors an existing, shipped code path). Confidence: HIGH.
+
+### [GATE-01] `bun test` rewrites docs/FORMAT-SUPPORT.md, defeating matrix:check
+
+- Severity: MEDIUM
+- Evidence:
+  - `scripts/format-matrix.ts:13,102-128`: module-scope side effects; when `--check` is absent from
+    argv, line 127 `writeFileSync(outPath, body)` runs at import time.
+  - `scripts/format-matrix.test.ts:7` imports that module, so every `bun test` run (the `test`
+    script includes `scripts/`) executes the write with today's date.
+  - `package.json` `verify:ci` runs `bun run test` BEFORE `bun run matrix:check`.
+- Mechanism: in CI, the test suite regenerates the file from the live registry, then `matrix:check`
+  compares the file on disk against a fresh regeneration of the same registry. Both sides are
+  freshly generated, so the comparison can never fail. The committed FORMAT-SUPPORT.md is never
+  actually gated.
+- Live proof: the baseline `bun run test` in this session rewrote `docs/FORMAT-SUPPORT.md`
+  (log line: `wrote .../docs/FORMAT-SUPPORT.md (28 adapters)`); the worktree was already dirty with
+  exactly this date-only diff before the audit began.
+- Impact: (1) the published FORMAT-SUPPORT.md on GitHub can drift stale from the adapter registry
+  with CI green, silently voiding the documented gate "matrix:check: FORMAT-SUPPORT.md matches
+  registry"; (2) every developer test run dirties the working tree, violating the repo's own
+  deterministic-test law (03-CONVENTIONS: no clock) and producing recurring noise diffs.
+- Systemic boundary: generator scripts that are both CLI entry points and test-imported libraries.
+  Only format-matrix has this defect today (the other hook tests import pure `-core`/`-lib`
+  modules), so the repair is local.
+- Effort: S. Fix risk: LOW. Confidence: HIGH.
+
+### [DOCS-01] Runnable-now docs teach the unbuilt `vaud` product; generated doc's commands fail
+
+- Severity: MEDIUM
+- Evidence (revised after adversarial review; the class is wider than first written):
+  - `docs/FORMAT-SUPPORT.md:10-13,80` (auto-generated, committed) tells users to run
+    `bun run vaud formats` / `vaud inspect` / `vaud convert` / `vaud validate` and to "Prefer
+    `vaud label`". Live proof: `bun run vaud formats` fails with `error: Script not found "vaud"`.
+    Template source: `scripts/format-matrix.ts:66-71` (usage block) and `:80` (Notes line).
+  - `docs/README.md:12-13` (the documentation front door, reference audience) states "Its engine
+    and CLI are called vaud"; `docs/README.md:39` describes reference/ui.md as "`vaud ui`, the
+    local server". The shipped CLI is `hoplight` (package.json `bin`).
+  - `docs/ROADMAP.md:81-82` lists the SHIPPED M1 exit criteria under `vaud convert / inspect /
+    validate ...` and `vaud upgrade` names.
+  - `docs/02-ARCHITECTURE.md` (AGENTS.md required reading #2) describes the future
+    `vaudeville-studios` repo: `packages/*`, a `vaud` CLI, a Tauri studio; none of it is this
+    repo. `docs/03-CONVENTIONS.md` mandates a `fixtures/<format>/<case>/` corpus (the repo uses
+    `samples/` plus per-format fixture folders) and `vaud` CLI conventions.
+  - Minor same-family defect: the built-in help (`src/cli.ts:126-131`) omits `--strict` from its
+    Options list while convert usage lines and docs/reference/cli.md document it.
+- Boundary correction (from review): the planning/reference split is NOT wholly unmarked.
+  `docs/README.md:50-53` already labels 01/02/03 "the founding planning docs" and points to
+  reference/architecture.md as the as-built truth. Three gaps remain: that marking never reached
+  AGENTS.md's required-reading table (which presents 02/03 as current); the marking file itself
+  carries the stale `vaud` claims above; and the same sentence calls 03-CONVENTIONS "the binding
+  code and process conventions", so 03 is simultaneously history and law.
+- Deliberately excluded from the finding: `specs/**` uses `vaud` throughout as the design-era CLI
+  name for future milestones (a consistent internal vocabulary, flagged for maintainer taste, not
+  a defect), and `docs/decisions/ADR-003` records the decision-era name (ADRs are history).
+  Engine docblocks mentioning `vaud convert` (three lorebook codecs) are internal comments, noted
+  only.
+- Impact: a newcomer following the binding reading order, the docs front door, or the format
+  matrix learns wrong architecture and pastes commands that fail.
+- Systemic boundary: stale product naming in runnable-now surfaces (generator template, docs
+  front door, shipped roadmap lines) plus the unpropagated planning-vs-reference marking.
+- Effort: S. Fix risk: LOW. Confidence: HIGH.
+
+### [UX-01] Damaged entity files silently vanish from the library
+
+- Severity: MEDIUM (code-read; frequency unknown, mechanism certain)
+- Evidence:
+  - `src/studio/store.ts:111-113`: `list()` wraps each per-file read in `catch { continue; }`.
+  - `src/studio/store.ts:124-146`: any JSON parse failure, schema rejection, kind mismatch, or id
+    mismatch throws `StudioReadError("corrupt entity file")`.
+  - `src/entities/runtime-schema.ts:37-102`: the character body schema requires all eight group
+    objects to exist, so a hand-edited or partially written file fails whole-cloth.
+  - No caller surfaces the skip: `/api/studio/list` (`src/ui/server.ts:326-332`) returns only the
+    survivors; the library app renders only what it receives.
+- Mechanism: a file that exists on disk in the user's studio folder but fails any read check is
+  omitted from every listing with no counter, no log the user sees, and no recovery path.
+- Impact: the flagship promise is local-first "files on your disk, yours"; a user whose card file
+  is damaged (crash mid-edit predating the atomic layer, hand edit, sync conflict, future schema
+  change) sees the card silently missing and has no signal that the bytes still exist and are
+  recoverable. This contradicts the repo doctrine of reporting storage and validation failures
+  honestly, and the fail-closed rule's spirit: fail closed, but visibly.
+- Systemic boundary: `StudioStore.list` owns the knowledge of skipped files; the HTTP list route
+  and library shelf must carry it through.
+- Effort: M. Fix risk: LOW-MEDIUM (touches store contract, its OPFS twin, one route, one app).
+  Confidence: HIGH on mechanism, MEDIUM on real-world frequency.
+
+### [TEST-01] No conversion-wiring coverage for non-character kinds
+
+- Severity: MEDIUM (prevention gap that let CORR-01 ship)
+- Evidence: `src/m1.convert.smoke.test.ts` exercises `convertFile` for character pairs only;
+  `src/convert.test.ts` and `src/cli-io.test.ts` add no regex/preset conversion; the 2,250-test
+  wall tests adapters individually (toCanonical/fromCanonical) but never the CLI wiring for regex,
+  preset, or persona kinds.
+- Impact: a whole entity kind can be (and was, twice) unreachable from the CLI with the suite
+  green.
+- Fix direction: registry-driven same-kind conversion smoke: for every registered adapter, emit a
+  minimal canonical entity of its kind, feed the output back through `convertFile` with itself and
+  with one sibling adapter of the same kind. Folded into Plan 001.
+
+### [PERF-01] Library listing and portrait serving re-parse full entity JSON
+
+- Severity: LOW (measured; recorded for the future, no plan)
+- Evidence: `src/studio/store.ts:87-114` (`list()` fully reads and zod-parses every entity,
+  including any multi-MB base64 `sourceMedia` carrier, to emit a summary);
+  `src/ui/server.ts:333-356` + `src/studio/portrait.ts:42-45` (each portrait request re-reads and
+  re-parses the full entity, then base64-decodes); `src/ui/apps/library/index.tsx:50` (the shelf
+  requests one portrait per card).
+- Measurement (this session, synthetic 40-entity library, ~4MB JSON each, Bun 1.3):
+  `list()` 88ms total (2.2ms/entity); portrait read 7.7ms each. Cost is linear in total library
+  bytes, dominated by escrow carriers; a 500-card heavyweight library projects to roughly 1.1s per
+  shelf load plus per-card portrait parses, with matching transient allocation churn.
+- Verdict: not worth a plan today; Bun's parser makes the current design acceptable at realistic
+  scale. Record: if archivist-scale libraries (1,000+ carrier-bearing cards) become a target, the
+  repair is a summary sidecar or lazy wrapper parse at the `StudioStore.list` boundary, not caching
+  in the UI.
+
+## Rejected and by-design candidates (recorded)
+
+- `registry.detect` has no try/catch around adapter `detect()` calls, so one throwing drop-in
+  detector would break detection for all formats. Probed live: all 28 registered detectors survive
+  malformed JSON, truncated PK/PNG bytes, 50k-deep JSON, null, and empty input without throwing.
+  The fail-closed doctrine is enforced by convention and holds today; hardening the registry loop
+  is optional polish, not a defect. REJECTED (no observed harm; discipline + detection firewall
+  tests cover it).
+- `convertFile` cross-kind refusal (character to lorebook, etc.): by design and documented; only
+  the same-kind gaps (CORR-01) are defects.
+- Version-switch system (highest recent churn): read end to end; deliberately fail-closed
+  (checksum verification, host allowlist on every redirect hop, size caps, storage-shape rollback
+  tripwire, dirty-tree refusal, prior-ref restore). No findings. The one prior tripwire bug was
+  already fixed in `733a2e8`.
+- Atomic write layer: exclusive create + fsync + rename-with-retry with a documented Windows live
+  repro. Sound. Orphaned `.tmp-*.json` files after a hard crash are invisible to `list()` (leading
+  dot fails the id policy) and accumulate harmlessly; not worth a finding.
+- `saveBundle` comment claims "Clone character shallowly" but mutates the caller's
+  `knowledgeRefs` in place (`src/studio/bundle.ts:126-131`); behavior is intended and harmless at
+  its single call site. Comment nit only.
+- Lore activation engine: loops bounded by `maxLoops`, recursion delays honored, provenance mapped
+  to ST world-info.js line ranges, dense test files. No findings at spot-check depth.
+- Detection tie-breaking is first-wins on equal scores (registry iteration order = loader's sorted
+  folder order). Deliberate score discipline (specific > generic) plus the cross-adapter firewall
+  test makes this a non-issue today.
+
+## Systemic themes
+
+1. Wiring lags the open format system. The format layer is genuinely drop-in, but two closed-union
+   seams above it (convertFile kinds; the matrix generator's usage text) fell behind reality
+   without any gate noticing. Theme owner: registry-driven property tests (Plan 001) and honest
+   generators (Plan 002).
+2. The `vaud`-era naming survives in runnable-now surfaces, and the planning-vs-reference marking
+   that docs/README.md already carries never propagated to AGENTS.md or to its own sentences; one
+   generator is also a test import. Plans 002 and 003 restore "docs move with the code" end to
+   end.
+3. Fail-closed is done well at parse boundaries, but failure VISIBILITY stops at the store layer
+   (UX-01).
+
+## Dependency graph
+
+```
+001 (CLI kind conversion)     independent
+002 (matrix gate integrity)   independent
+003 (docs truth alignment)    soft-after 002 (the regenerated matrix should land behind an honest gate)
+004 (damaged-entity surfacing) independent
+```
+
+Recommended execution order: 002, 001, 003, 004. Until 002 lands, any plan whose broad checks run
+`bun run test` must discard the known GATE-01 side-effect diff on docs/FORMAT-SUPPORT.md before
+judging its own scope (each plan says so where it applies).
+
+## Adversarial review
+
+A blind fresh-context reviewer (same model family, no shared conversation state) verified every
+citation and attempted falsification. Initial verdicts: all six artifacts REVISE; zero CRITICAL
+defects; all four finding mechanisms confirmed (CORR-01, DOCS-01 reproduced live by the reviewer
+independently; GATE-01 evidence and the worktree's predicted date-only dirt confirmed; every UX-01
+citation opened). Five MAJOR and six MINOR objections were raised; all were re-verified against
+source by the conductor and every one held, so all were revised into the current artifacts:
+
+- M1/M2/M3: DOCS-01 under-scoped and mis-attributed (docs/README.md already marks the planning
+  docs, itself carries `vaud` claims, and calls 03 binding; `vaud label` in the generator Notes
+  line and ROADMAP's shipped lines survived the original plan). Finding and Plan 003 rewritten.
+- M4: Plan 004 cited a shared notice-component family that does not exist (the only cataloged
+  notice is workbench-local; Settings hand-rolls local classes). UI approach rewritten to an
+  app-local band.
+- M5: Plan 001's scope done-criterion was unsatisfiable before Plan 002 lands (GATE-01 side
+  effect). Step 4 and the criterion now handle it explicitly.
+- m1-m6: fabricated evidence wording in Plan 002's do-not-touch note, a type the Plan 002 code
+  shape missed (`row`), two stale line anchors in Plan 001, a false "AGENTS.md restates the
+  testing law" claim in Plan 003, untracked CLAUDE.md cited as authority, and a wrong test
+  exemplar in Plan 004. All corrected.
+
+Post-revision status: the conductor holds the revised artifacts SHIPPABLE for their purpose
+(planning artifacts; no plan has been executed). The reviewer's full report is preserved in the
+PR discussion.

--- a/audit-plans/README.md
+++ b/audit-plans/README.md
@@ -1,0 +1,72 @@
+# audit-plans
+
+Systemic audit of Hoplight plus executor-ready implementation plans.
+
+- Scope: whole repository at commit `80451e6` (Mainstage, v0.1.13), 2026-07-24.
+- Mode: `audit standard direct` (conductor-only, no shards). Security and privacy categories were
+  EXCLUDED by operator instruction; silence on them is not a clean bill.
+- Auditor: Claude Fable 5, branch `audit/grumpy-fable-5` (model-benchmark session; a parallel
+  Opus session audits the same tree on its own branch).
+- Verification baseline at planning: `bun run typecheck` clean; `bun run test` 2250 pass / 1 skip /
+  0 fail. Full record: [AUDIT.md](AUDIT.md).
+
+## Recommended execution sequence
+
+1. `002` make the format matrix gate real (smallest, restores gate honesty first)
+2. `001` restore regex and preset CLI conversion (highest user-facing value)
+3. `003` align front-door docs with the built product (regen lands behind the honest gate)
+4. `004` surface damaged entities in the library
+
+## Dependency graph
+
+```
+002 ──(soft: regen honesty)──────> 003
+002 ──(soft: scope-check hygiene)─> 001
+004   independent
+```
+
+No hard blockers. Until 002 lands, 001's Step 4 discards the known GATE-01 side-effect diff
+before judging scope, and 003 states one STOP tied to 002's landing state.
+
+## Status table
+
+| Plan | Title | Priority | Category | Effort | Risk | Depends on | Status | Last verified |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [001](001-restore-regex-and-preset-cli-conversion.md) | Restore regex and preset CLI conversion | P1 | correctness | S-M | LOW | none (soft: 002) | READY | 2026-07-24 |
+| [002](002-make-the-format-matrix-gate-real.md) | Make the format matrix gate real | P2 | tests/delivery | S | LOW | none | READY | 2026-07-24 |
+| [003](003-align-front-door-docs-with-the-built-product.md) | Align front-door docs with the built product | P3 | docs/DX | S | LOW | none (soft: 002) | READY | 2026-07-24 |
+| [004](004-surface-damaged-entities-in-the-library.md) | Surface damaged entities in the library | P4 | UX/data | M | LOW-MED | none | READY | 2026-07-24 |
+
+Statuses: TODO, READY, IN PROGRESS, BLOCKED, DONE, STALE, REJECTED.
+
+## Findings without plans
+
+- PERF-01 (LOW, measured): library list/portrait full-parse cost is linear in library bytes;
+  88ms per 40 heavyweight entities today. Recorded in AUDIT.md as not worth doing now, with the
+  repair boundary named for when archivist-scale libraries become a target.
+
+## Considered and rejected
+
+See the rejected ledger in [AUDIT.md](AUDIT.md): registry detect hardening (probed, holds),
+switch-system candidates (read end to end, fail-closed by design), atomic-write layer (sound),
+saveBundle comment nit, lore engine spot check, detection tie-breaking.
+
+## Cross-plan conflicts
+
+- 002 and 003 both touch `scripts/format-matrix.ts` (different regions: entry guard vs template
+  strings at 66-71 and 80) and 003 regenerates `docs/FORMAT-SUPPORT.md`. Execute serially in the
+  recommended order; do not run them as concurrent executors.
+- 001 and 004 share no files with any other plan.
+
+## Adversarial review
+
+A blind fresh-context reviewer returned REVISE on all six artifacts (0 CRITICAL, 5 MAJOR,
+6 MINOR); every objection was conductor-verified against source, held, and was revised into the
+current artifacts. Full record: AUDIT.md's "Adversarial review" section; the raw report lives in
+the PR discussion.
+
+## Updating status
+
+Edit only the Status and Last verified cells of the table above (plus a one-line note under the
+plan's own Status section when it moves to IN PROGRESS / DONE / BLOCKED). Do not renumber plans,
+do not rewrite history; a superseded approach gets a new plan file that links back.


### PR DESCRIPTION
## What this is

A whole-repository systemic audit of Hoplight at `80451e6` (v0.1.13), run with the
`grumpy-systemic-audit` skill in `audit standard direct` mode (conductor-only, no shards), plus
four executor-ready implementation plans. This PR adds planning artifacts only under
`audit-plans/`; no source, docs, or config files are touched.

**AI model disclosure (per CONTRIBUTING.md): Claude Fable 5** (`claude-fable-5`). This is the
Fable half of a two-model benchmark; a parallel session runs the same skill on another branch.

**Scope exclusion:** security and privacy categories were explicitly excluded by the operator.
Silence on them is not a clean bill.

## Verification baseline

- `bun run typecheck`: clean
- `bun run test`: 2250 pass / 1 skip / 0 fail (5.3s)

## Findings (all conductor-verified against source; key ones live-reproduced)

| ID | Sev | Finding | Proof |
| --- | --- | --- | --- |
| CORR-01 | HIGH | `hoplight convert` cannot convert regex or preset files (5 regex + 4 preset adapters are registered and advertised); the error blames "different entity kinds" for a same-kind request. The studio export path already does this correctly, so it is pure CLI wiring rot. | live-proven, both repros exit 1 |
| GATE-01 | MED | `bun test` rewrites `docs/FORMAT-SUPPORT.md` via an import-time side effect in `scripts/format-matrix.ts`; since `verify:ci` runs tests before `matrix:check`, the stale-matrix gate can never fail in CI, and every dev test run dirties the tree. | live-proven |
| DOCS-01 | MED | AGENTS.md-mandated reading (docs/02, 03) describes the unbuilt `vaudeville-studios`/`vaud` product; the committed, auto-generated FORMAT-SUPPORT.md instructs four `bun run vaud ...` commands that all fail on paste. | live-proven |
| UX-01 | MED | Entity files that fail to read are silently skipped by `StudioStore.list()`: a damaged card vanishes from the library with no signal the bytes still exist. | code-read |
| TEST-01 | MED | No conversion-wiring test covers non-character kinds, which is how CORR-01 shipped twice (preset, then regex). | code-read |
| PERF-01 | LOW | Library list/portrait re-parse full entity JSON incl. base64 carriers; measured 88ms/40 heavyweight cards, linear in library bytes. Recorded as not worth fixing yet. | measured |

Rejected candidates (registry detect hardening, switch-system concerns, atomic-write layer, lore
engine spot checks) are recorded with evidence in `audit-plans/AUDIT.md`; the version-switch and
atomic-write layers came out clean and are called out as such.

## Plans

| Plan | Outcome | Effort |
| --- | --- | --- |
| 001 | Generic same-kind path in `convertFile` + registry-wide conversion sweep test | S-M |
| 002 | Entry-guard `scripts/format-matrix.ts` so tests stop writing docs and `matrix:check` really gates | S |
| 003 | Planning-era preambles on docs/02+03, fix the generated usage block to `bun run hoplight`, add `--strict` to built-in help | S |
| 004 | `listDamaged()` + `/api/studio/damaged` + a library notice band for unreadable files | M |

Recommended order: 002, 001, 003, 004. Each plan carries exact anchors, RED/GREEN gates, live
journeys, done criteria, STOP conditions, and rollback notes; they are written for a
context-poor executor.

## Adversarial review

A blind fresh-context reviewer (also Fable 5, no shared conversation state) opened every cited
file:line, independently re-reproduced CORR-01 and DOCS-01 live, and tried to falsify each root
cause. It returned REVISE on all six artifacts: 0 CRITICAL, 5 MAJOR, 6 MINOR defects, the sharpest
being that my original DOCS-01 under-scoped the stale-naming class (docs/README.md itself says
"Its engine and CLI are called vaud") and that plan 004 leaned on a shared notice component that
does not exist. Every objection was conductor-verified, held, and is revised into the committed
artifacts; the full reviewer report is posted as a comment below, and AUDIT.md records the
before/after.

## Notes for the maintainer

- Suggest `[skip release]` in the squash/merge commit message (per CONTRIBUTING.md this marker
  must be in the landing commit itself); this PR is planning artifacts only.
- The one dirty file this branch does NOT touch: `docs/FORMAT-SUPPORT.md` regenerates its date
  stamp on every `bun test` run in any checkout; that is finding GATE-01, fixed by plan 002.
