### PR TITLE
docs(audit): systemic audit of Hoplight by Claude Opus 5

### DIFF
--- a/audit-plans/opus-5/001-stop-pygmalion-dropping-portraits.md
+++ b/audit-plans/opus-5/001-stop-pygmalion-dropping-portraits.md
@@ -1,0 +1,201 @@
+# Plan 001: Stop Pygmalion export dropping portraits behind a clean honesty report
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: 1
+- Category: correctness, data loss
+- Effort: S
+- Risk: LOW
+- Depends on: nothing
+- Planned at: `80451e6`, 2026-07-24
+- Finding: F-06
+
+## Outcome
+
+Converting a character that has a portrait into Pygmalion either keeps the portrait, or reports it
+as dropped. It never does what it does today, which is lose it and report success.
+
+## Why this matters
+
+Hoplight's honesty reporting exists so a user knows what a conversion costs before they accept it.
+For this one path it asserts the opposite of the truth. A silent loss behind a clean report is worse
+than a loud loss, because the user has been given a reason not to check.
+
+Live-proven on four samples across three source formats:
+
+```
+samples/backyard/characters/2.byaf            -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/backyard/characters/3.byaf            -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/sillytavern/characters/v3-full.json   -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/rolecall/characters/vera-casting-card -> pygmalion  .json  image=NO  portrait reported dropped? false
+```
+
+Each source entity genuinely populates `body.media.portrait`. Each output carries no image. None
+reports the loss.
+
+## Proven root cause
+
+`src/formats/pygmalion/coverage.ts:17` lists `"media.portrait"` in `carries`.
+
+`src/formats/pygmalion/index.ts:150-168` `fromCanonical` emits a PNG carrier **only** when the
+entity has Pygmalion's own escrow:
+
+```ts
+const sm = esc?.sourceMedia as { b64?: string; mime?: string } | undefined;
+if (sm && typeof sm.b64 === "string" && sm.mime === "image/png") {
+  // ... embedCharacterJson -> { bytes, suggestedExtension: "png" }
+}
+return { text, suggestedExtension: "json" };   // :168, portrait gone
+```
+
+It never reads `entity.body.media.portrait`. A character imported from any other format has no
+`original.pygmalion`, so `sm` is undefined and the JSON branch runs.
+
+`src/core/reports.ts:87` builds the dropped list as everything the target's `CoverageDecl` does not
+cover, via `coversPath`. Because `media.portrait` is declared covered, the loss is exempted.
+
+The declaration already contradicts itself. `coverage.ts:22` notes: "PNG carrier pixels when
+imported from a Pygmalion-style chara PNG; not a card key". That is accurate and it is the narrower
+truth. But `notes` is prose for humans and `carries` is the machine-readable claim `coversPath`
+consumes unconditionally, so the honest note has no effect on the report.
+
+`src/core/coverage.ts:7-8` predicts exactly this failure mode: "the round-trip harness that
+mechanically pins claims to codec reality is tracked follow-up work - until then a wrong claim is a
+bug in that format's folder".
+
+## Target architecture
+
+Two options. They are not equivalent and the choice is a product decision, so make it deliberately.
+
+| Option | Change | User result | Effort |
+| --- | --- | --- | --- |
+| A. Honor the portrait | `fromCanonical` falls back to `body.media.portrait` when no escrow exists, emitting a PNG carrier | Portrait survives cross-format conversion | S |
+| B. Tell the truth | Remove `"media.portrait"` from `carries` | Portrait still lost, but the report says so | XS |
+
+**Prefer A**, because Pygmalion's wire format demonstrably supports an embedded portrait (the escrow
+path already produces one via `embedCharacterJson`), so the capability exists and only the fallback
+is missing. B alone leaves a real capability gap while merely documenting it.
+
+If A cannot be done safely, ship B immediately rather than leaving the false claim standing. B is
+strictly better than today and takes one line.
+
+Under A, the shape is: when `sm` is absent, read `entity.body.media.portrait`, decode it to PNG
+bytes, and take the same `embedCharacterJson` path. `media.portrait` is a `MediaAsset`
+(`src/entities/character/schema.ts:170`), and `src/formats/pygmalion/index.ts:103` `portraitFromPng`
+already shows the inverse conversion, so it is the exemplar for shape and role handling.
+
+## Files
+
+### Modify
+- `src/formats/pygmalion/index.ts`: `fromCanonical` (`:150`). Add the fallback. Do not disturb the
+  escrow branch, which is correct and is what makes same-format round trips lossless.
+- `src/formats/pygmalion/coverage.ts`: under option B, remove `"media.portrait"` from `carries`.
+  Under option A, keep it and tighten the note at `:22` to describe the new behavior truthfully.
+- `src/formats/pygmalion/pygmalion.test.ts`: add the cases below.
+
+### Do not touch
+- `src/core/reports.ts` or `src/core/coverage.ts`. The reporting machinery is correct; it faithfully
+  reported what the declaration told it. Changing the engine to compensate for one wrong declaration
+  would hide the next one.
+- Any other format's `coverage.ts`. Auditing the rest is real work (see Maintenance notes) but it is
+  not this plan.
+- `samples/**`.
+
+## Implementation steps
+
+### Step 1: Red first, at the public boundary
+
+Add to `src/formats/pygmalion/pygmalion.test.ts`: take a character parsed from a non-Pygmalion
+sample that populates `body.media.portrait` (use `samples/sillytavern/characters/v3-full.json`,
+proven above), pass it to the Pygmalion adapter's `fromCanonical`, and assert **both**:
+
+1. the output carries the portrait (option A) or the serialize report lists `media.portrait` as
+   dropped (option B);
+2. `media.assets` still appears in the dropped list, so the test cannot pass by breaking reporting
+   generally.
+
+Verify: `bun test src/formats/pygmalion` -> the new case FAILS. Record the output verbatim. This is
+the honest RED, and it must fail for the right reason: portrait absent AND unreported.
+
+### Step 2: Implement the chosen option
+
+Apply A or B. If A, keep the escrow branch first so same-format conversions are byte-unchanged.
+
+Verify: `bun test src/formats/pygmalion` -> pass, with the step 1 assertions unedited.
+
+### Step 3: Prove the same-format round trip did not regress
+
+The escrow path is what makes Pygmalion PNG to Pygmalion PNG lossless. Confirm it still is.
+
+Verify: `bun test src/formats/pygmalion src/m1.convert.smoke.test.ts` -> pass, including the
+existing round-trip assertion at `src/formats/pygmalion/pygmalion.test.ts:68`.
+
+### Step 4: Re-run the audit's own reproduction
+
+Convert all four samples from the finding and confirm the outcome changed:
+
+```bash
+bun run hoplight -- convert samples/sillytavern/characters/v3-full.json --to pygmalion /tmp/p.json
+bun run hoplight -- convert samples/backyard/characters/2.byaf --to pygmalion /tmp/p2.json
+```
+
+Verify: under A the output is a `.png` carrying the portrait; under B the printed report lists
+`media.portrait` among the dropped fields. Either way the silent loss is gone.
+
+### Step 5: Full wall
+
+Verify: `bun run verify:ci` -> EXIT 0.
+
+## Test plan
+
+- Baseline: `bun run verify:ci` green at `80451e6` (2250 pass, 0 fail).
+- Honest RED: step 1, recorded verbatim.
+- Unchanged GREEN: step 1's assertions after step 2, unedited.
+- Named cases: cross-format portrait handling; same-format escrow round trip unchanged;
+  `media.assets` still reported dropped (the anti-vacuity assertion).
+- Exemplar: `src/formats/pygmalion/pygmalion.test.ts:68` for round-trip style.
+- Adjacent: `bun run test:m1`, `bun test src/formats src/core`.
+- Broad: `bun run verify:ci`.
+
+## Documentation and operations
+
+- `docs/reference/formats/` page for Pygmalion: state truthfully whether portraits survive a
+  cross-format import. This is the surface users read before converting.
+- `bun run matrix` only if adapter metadata changed. Coverage edits do not change the matrix.
+
+## Done criteria
+
+- `bun run verify:ci` -> EXIT 0.
+- The four-sample reproduction no longer shows a portrait lost without report.
+- The same-format Pygmalion round trip still passes.
+- `media.assets` still appears in dropped lists, proving reporting was not broadened into silence.
+- `coverage.ts` `carries` and its `notes` no longer disagree with each other.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- Option A produces a PNG that Pygmalion or SillyTavern cannot re-read. A corrupt carrier is worse
+  than a missing portrait. Fall back to B and report.
+- The fallback would require decoding an arbitrary user-supplied data URI into image bytes without
+  a size bound. Bound it or stop; `src/studio/portrait.ts:15-18` has the existing raster-only
+  allowlist to reuse, and SVG must stay excluded.
+- Other formats turn out to have the same class of over-claim. Record them, do not fix them here.
+
+## Rollback and recovery
+
+Revert the two source files and the tests. No stored data changes. Files already exported with a
+missing portrait are unaffected either way; this plan changes future exports only.
+
+## Maintenance notes
+
+- The general defect is that `carries` is an unverified claim. `src/core/coverage.ts:7-8` says so.
+  Pygmalion is the instance this audit proved; `marinara`, `novelai`, and `vaud-json` ship **no**
+  `coverage.ts` at all and `sillytavern-preset` omits its declaration
+  (`src/formats/sillytavern/preset.ts:29`). A harness that pins every declaration against real codec
+  behavior would close the class. That is the honest follow-up and it is larger than this plan.
+- Reviewer trap: making the test pass by deleting the coverage declaration entirely would also
+  delete the true claims. Only `media.portrait` is wrong.

--- a/audit-plans/opus-5/002-lint-every-ui-typescript-file.md
+++ b/audit-plans/opus-5/002-lint-every-ui-typescript-file.md
@@ -1,0 +1,219 @@
+# Plan 002: Lint every TypeScript file under src/ui, not just the .tsx ones
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: 2
+- Category: tests, delivery
+- Effort: M (the config change is XS; the backlog it exposes is the work)
+- Risk: LOW
+- Depends on: nothing
+- Planned at: `80451e6`, 2026-07-24
+- Finding: F-07
+
+## Outcome
+
+`bun run lint:ui` covers every authored TypeScript file under `src/ui`, so a rules-of-hooks
+violation in a `.ts` file fails CI instead of shipping. `AGENTS.md:110` becomes true.
+
+## Why this matters
+
+`eslint.config.mjs:51` calls `react-hooks/rules-of-hooks` an error because "conditional/looped hooks
+corrupt React's dispatcher state". That rule currently does not run on the three files that define
+React hooks outside JSX:
+
+- `src/ui/shell/menus.ts` (`useContextMenu`)
+- `src/ui/apps/workbench/use-variants.ts`
+- `src/ui/apps/workbench/lore/use-marinara-folders.ts`
+
+188 non-test `.ts` files under `src/ui` are unlinted in total, including `api.ts`, `docs-corpus.ts`
+(path containment), and everything under `_shared/` and `remote/`.
+
+Live-proven. I planted a conditional `useState` in `use-variants.ts`:
+
+```
+bun run lint:ui                                    -> EXIT 0, clean
+bunx eslint src/ui/apps/workbench/use-variants.ts  -> "File ignored because no matching configuration was supplied"
+the identical code in a .tsx file                  -> error react-hooks/rules-of-hooks
+bun run verify:ci                                  -> EXIT 0, 2250 pass, 0 fail
+```
+
+The rule works. The scoping excludes the files. The complete wall shipped it.
+
+## Proven root cause
+
+Two independent scopings, both `.tsx` only, so widening one alone changes nothing:
+
+```jsonc
+// package.json:38
+"lint:ui": "bunx eslint \"src/ui/**/*.tsx\" --max-warnings 0",
+```
+
+```js
+// eslint.config.mjs:43
+files: ["src/ui/**/*.tsx"],
+```
+
+The config `files` key is the load-bearing one: with no matching config block, eslint ignores a
+`.ts` file even when it is named explicitly on the command line, which is exactly what the
+"File ignored because no matching configuration was supplied" message reports.
+
+Inference, labelled: the config was written when the React shell was assumed to be entirely `.tsx`,
+and the custom hooks and `_shared` helpers arrived later as `.ts`.
+
+## Target architecture
+
+```js
+// eslint.config.mjs
+{
+  files: ["src/ui/**/*.{ts,tsx}"],          // was: ["src/ui/**/*.tsx"]
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+  plugins: { "react-hooks": reactHooks },
+  rules: { /* unchanged */ },
+},
+{
+  // JSX-shaped rules stay .tsx-only: they match JSXOpeningElement selectors
+  files: ["src/ui/apps/**/*.tsx", "src/ui/shell/**/*.tsx"],
+  rules: { "no-restricted-syntax": ["error", ...restrictedPrimitives, ...NATIVE_REINVENTIONS] },
+},
+```
+
+```jsonc
+// package.json
+"lint:ui": "bunx eslint \"src/ui/**/*.{ts,tsx}\" --max-warnings 0",
+```
+
+The second block stays `.tsx`-only deliberately. Its rules are `no-restricted-syntax` selectors
+matching `JSXOpeningElement` (`eslint.config.mjs:36`), which cannot match in a file with no JSX, so
+widening it would add cost and no coverage.
+
+Test files are the open question. `react-hooks/exhaustive-deps` is a warning and `--max-warnings 0`
+makes warnings fatal, so a large test-file backlog could block this plan on unrelated churn. Decide
+in step 2 with evidence, not in advance.
+
+## Files
+
+### Modify
+- `eslint.config.mjs`: the `files` key at `:43`.
+- `package.json`: the `lint:ui` script at `:38`.
+- `AGENTS.md:110`: the gate table description, if the final scope differs from "the React shell".
+- Whatever `src/ui/**/*.ts` files the newly-enabled rules flag. Fix the violations; do not disable
+  the rules.
+
+### Do not touch
+- The rule set itself. This plan changes **scope**, not policy. If a rule turns out to be wrong for
+  `.ts` files, that is a separate decision with its own rationale.
+- `scripts/hooks/**`. The other gates are unaffected.
+
+## Implementation steps
+
+### Step 1: Measure the backlog before committing to it
+
+```bash
+bunx eslint "src/ui/**/*.{ts,tsx}" --format=compact | tail -40
+bunx eslint "src/ui/**/*.{ts,tsx}" --format=compact | grep -c "Error"
+bunx eslint "src/ui/**/*.{ts,tsx}" --format=compact | grep -c "Warning"
+```
+
+This runs against the current config, so it reports what the widened scope will surface once the
+config `files` key is widened too. Record both counts in the PR before changing anything.
+
+Verify: counts recorded. If errors are zero and warnings are small, this plan is XS. If either is
+large, go to the decision in step 2.
+
+### Step 2: Decide the test-file boundary
+
+| Situation | Action |
+| --- | --- |
+| Backlog is small (say under 20 warnings) | Widen to all `src/ui/**/*.{ts,tsx}` including tests, fix them, done |
+| Backlog is large and concentrated in `*.test.ts` | Widen to non-test `.ts` first, add tests in a follow-up, and say so in the PR rather than leaving it implied |
+| Backlog is large in production `.ts` | Still widen. A large backlog is the finding, not a reason to skip. Fix in this plan or split with an explicit tracking note |
+
+Never resolve a backlog by raising `--max-warnings`. That converts a real gate into a decorative one
+and is the same class of defect this plan exists to fix.
+
+### Step 3: Widen both scopings
+
+Apply the config and script changes. Both, together. Widening only `package.json` does nothing,
+which is the trap here.
+
+Verify: `bunx eslint src/ui/apps/workbench/use-variants.ts` no longer prints
+"File ignored because no matching configuration was supplied".
+
+### Step 4: Prove the gate can now fail honestly
+
+Re-run the audit's probe. Plant a conditional hook in `src/ui/apps/workbench/use-variants.ts`:
+
+```ts
+if (variantsOf(baseDraft).length > 99) {
+  useState<string | null>(null);
+}
+```
+
+Verify: `bun run lint:ui` -> FAILS with `react-hooks/rules-of-hooks`. Record the output. Revert the
+probe. This is the single assertion that proves the plan worked; without it the change is unproven.
+
+### Step 5: Clear the backlog
+
+Fix every error and warning the widened scope surfaces. For `exhaustive-deps` findings, fix the
+dependency array rather than adding a disable comment, unless the case genuinely matches the
+documented mount-once exception already used at `src/ui/shell/App.tsx:283-286`, in which case follow
+that precedent including its inline reason.
+
+Verify: `bun run lint:ui` -> EXIT 0.
+
+### Step 6: Full wall
+
+Verify: `bun run verify:ci` -> EXIT 0.
+
+## Test plan
+
+- Baseline: `bun run verify:ci` green at `80451e6`.
+- Honest RED: step 4, recorded verbatim. The planted violation must fail `lint:ui`.
+- Unchanged GREEN: `lint:ui` clean after reverting the probe.
+- Regression: `bun run test` must stay at 2250 pass. Lint fixes that change behavior are a STOP
+  condition, not a test to update.
+- Broad: `bun run verify:ci`.
+
+## Documentation and operations
+
+- `AGENTS.md:110` currently reads "eslint on the React shell, zero warnings". Make it match the final
+  scope, for example "eslint on all authored TS/TSX under src/ui, zero warnings".
+- `CLAUDE.md` repeats the gate list; check it too.
+
+## Done criteria
+
+- `bun run verify:ci` -> EXIT 0.
+- `bun run lint:ui` covers `.ts` files, proven by step 4's recorded failure.
+- Backlog counts from step 1 recorded in the PR, and the final disposition of each stated.
+- `--max-warnings 0` is unchanged.
+- `bun run test` still reports 2250 pass.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- A lint fix would change runtime behavior. `exhaustive-deps` fixes can alter effect timing and
+  cause real bugs. Stop, isolate that file, and handle it as its own change with its own test.
+- The backlog is so large that fixing it in one pass is not reviewable. Split by directory, land the
+  scope widening with a documented, dated exclusion list, and never leave the exclusion implicit.
+- Widening reveals that `.ts` files legitimately need a different rule set. Stop and re-plan; this
+  plan assumes scope, not policy, is wrong.
+
+## Rollback and recovery
+
+Config and lint fixes only. Revert `eslint.config.mjs` and `package.json` to restore the old scope.
+Any behavior-neutral lint fixes can stay.
+
+## Maintenance notes
+
+- The failure mode was a glob that silently narrowed a gate. `scripts/hooks/prose-guards.ts` walks
+  `docs/ specs/ src/ scripts/ templates/` plus three named root files, and
+  `scripts/hooks/doctrines.ts` has its own roots. Those are the same shape of hand-maintained scope
+  and are worth the same look; this audit did not check whether they under-cover.
+- Reviewer trap: a green `lint:ui` after this change proves nothing on its own. The proof is step 4.

--- a/audit-plans/opus-5/003-run-sidecar-tests-in-ci.md
+++ b/audit-plans/opus-5/003-run-sidecar-tests-in-ci.md
@@ -1,0 +1,201 @@
+# Plan 003: Run the sidecar's authorization tests in CI
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: 3
+- Category: tests, delivery, security
+- Effort: S
+- Risk: LOW
+- Depends on: nothing
+- Planned at: `80451e6`, 2026-07-24
+- Finding: F-08
+
+## Outcome
+
+`sidecar/main_test.go` runs on every push and pull request. A change that breaks the remote-access
+authorization gate fails CI instead of merging green.
+
+## Why this matters
+
+The Go sidecar is the trust boundary between a Tailscale network and the local studio. All nine of
+its tests guard authorization:
+
+```
+TestProxyDeniesUnidentifiedCaller          TestProxyDeniesNodeWithoutStableID
+TestProxyDeniesNonOwner                    TestDeviceTrackerKick
+TestProxyFailsClosedWhenOwnerUnresolved    TestProxyDeniesKickedDevice
+TestProxyStampsIdentityFromWhoIsNotFromClient
+TestProxyOmitsSecretWhenUnset              TestSecretsEqualConstantTime
+```
+
+Identity spoofing prevention, non-owner denial, kicked-device enforcement, constant-time secret
+comparison. Someone wrote careful tests for exactly the right things, and CI never runs one of them.
+
+Worse, `go build` never runs either, so the sidecar is not even compile-checked. A Go change that
+does not compile can merge, and `.github/workflows/ci.yml` will be green.
+
+## Proven root cause
+
+No workflow under `.github/workflows/` contains a Go step: `ci.yml` runs only `bun run verify:ci`,
+and `verify:ci` (`package.json:41`) is 17 Bun and TypeScript gates with no Go among them.
+`release.yml` builds through `scripts/build-desktop.ts` for three platforms and contains no sidecar
+reference.
+
+Inference, labelled: `sidecar/build.ts` documents itself as a manual step ("Run: `bun sidecar/build.ts`"),
+so the sidecar was likely always built by hand and never joined the automated pipeline.
+
+## Current architecture and authority
+
+- `sidecar/main.go` (464 lines): `serve:268`, `newProxy:354`, header strip and stamp at `:366,:375`,
+  `secretsEqual:462`, `resolveOwnerID:220`, `deviceTracker:94`.
+- `sidecar/main_test.go` (191 lines): the nine tests above.
+- `sidecar/go.mod`, `go.sum`: pinned module graph, so CI can build reproducibly.
+- Consumed from TypeScript by `src/ui/remote/sidecar-manager.ts`, which spawns the binary and reads
+  line-delimited JSON from its stdout.
+- `src/ui/server-remote.ts:27`: "Resolve the bundled Tailscale sidecar binary. A missing binary fails
+  soft."
+
+## Target architecture
+
+A Go job in `ci.yml`, parallel to the existing `test` job so it neither slows nor is slowed by the
+Bun wall:
+
+```yaml
+  sidecar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: sidecar/go.mod
+          cache-dependency-path: sidecar/go.sum
+      - name: Vet
+        run: go vet ./...
+        working-directory: sidecar
+      - name: Test
+        run: go test ./... -count=1
+        working-directory: sidecar
+```
+
+`go-version-file: sidecar/go.mod` pins the toolchain to what the module already declares, so the
+version lives in one place. `-count=1` disables the test cache so a green result always means the
+tests actually ran, which matters for a job whose entire purpose is that they run.
+
+Deliberately **not** in scope: adding the sidecar to `release.yml`. See Maintenance notes; that is a
+distribution question with its own risks and needs its own decision.
+
+## Files
+
+### Modify
+- `.github/workflows/ci.yml`: add the `sidecar` job.
+- `AGENTS.md` section 4 and `CLAUDE.md`: the gate tables describe `verify:ci` as the whole wall. If
+  CI now runs a gate outside `verify:ci`, say so, or the same claim-versus-reality gap this finding
+  is about simply moves.
+
+### Do not touch
+- `sidecar/main.go`. This plan runs the existing tests; it does not change behavior.
+- `sidecar/main_test.go`, unless step 1 shows a test is already failing. See STOP conditions.
+- `package.json`. Adding `go test` to `verify:ci` would break `bun run verify:ci` for every
+  contributor without a Go toolchain, and the pre-push hook with it. Keep it a CI job.
+
+## Implementation steps
+
+### Step 1: Establish the Go baseline locally
+
+```bash
+cd sidecar && go vet ./... && go test ./... -count=1 -v
+```
+
+Verify: record the result verbatim. **This audit could not run this step**, because the Go toolchain
+is not installed on the auditing machine. The tests are therefore of unknown current status. If any
+fail, that is a finding in its own right and a STOP condition, not something to wire into CI as a
+known-red job.
+
+### Step 2: Add the job
+
+Apply the workflow change above.
+
+Verify: `bunx --yes yaml-lint .github/workflows/ci.yml` or equivalent parse check; the file must
+remain valid YAML.
+
+### Step 3: Prove the job can fail honestly
+
+On a scratch branch, deliberately invert one authorization check, for example make `secretsEqual`
+(`sidecar/main.go:462`) return `true` unconditionally, and push.
+
+Verify: the `sidecar` job FAILS, and `TestSecretsEqualConstantTime` plus at least one proxy-denial
+test are among the failures. Record the run URL. Revert. A job that has never been observed failing
+is not yet a gate.
+
+### Step 4: Confirm CI wiring end to end
+
+Verify: on a normal pull request, both the `test` job and the new `sidecar` job appear and pass.
+Confirm in the Actions UI, not by assumption.
+
+### Step 5: Reconcile the documentation
+
+Update `AGENTS.md` section 4 so the gate list reflects that CI runs Go tests in addition to
+`verify:ci`. Do the same wherever `CLAUDE.md` describes the wall.
+
+Verify: `bun run verify:ci` -> EXIT 0 (the docs gates are inside it).
+
+## Test plan
+
+- Baseline: `bun run verify:ci` green at `80451e6`; Go baseline from step 1.
+- Honest RED: step 3, with the run URL recorded.
+- Unchanged GREEN: step 4.
+- Regression: the existing `test` job is untouched and must stay at 2250 pass.
+- Explicitly out of scope: no new Go tests are written here. Wiring the existing ones is the whole
+  outcome.
+
+## Documentation and operations
+
+- Note in the PR that `go test` is intentionally a CI job rather than part of `verify:ci`, so
+  contributors without Go can still run the local wall.
+- If the repository has a branch ruleset requiring status checks, the new `sidecar` check must be
+  added to the required list, or it can fail without blocking a merge and this plan achieves
+  nothing. `CONTRIBUTING.md:50` mentions the recommended protection; whoever owns that setting has
+  to make this change too. Flag it explicitly in the PR.
+
+## Done criteria
+
+- `.github/workflows/ci.yml` contains a Go job that runs `go vet` and `go test ./... -count=1`.
+- Step 3's deliberate break produced a red `sidecar` job, with the run URL recorded.
+- A normal PR shows both jobs green.
+- The required-status-checks list includes the new job, or the PR states plainly that a maintainer
+  must add it.
+- `AGENTS.md` no longer implies `verify:ci` is the complete gate wall.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- **Any sidecar test fails at step 1.** Stop. A currently-failing authorization test on the
+  remote-access boundary is a security finding, and it must be reported privately per `SECURITY.md`
+  rather than wired into CI as a known-red job or disclosed in a public PR.
+- `go vet` reports issues that require changing `main.go`. Fix in a separate change so this plan
+  stays "run what exists".
+- The module cannot build in CI because of a private or unavailable dependency in `go.sum`.
+- Adding a required check would block all in-flight PRs. Coordinate the rollout instead of
+  surprising contributors.
+
+## Rollback and recovery
+
+Remove the job from `ci.yml`. No source, data, or distribution change. If the required-checks list
+was updated, remove the entry there too, otherwise every PR blocks on a check that no longer runs.
+
+## Maintenance notes
+
+- **The unresolved question this plan does not answer:** `release.yml` never builds the sidecar, and
+  `src/ui/server-remote.ts:27` says a missing binary fails soft. So it is not established that
+  official release artifacts contain a sidecar at all, and the remote-access feature may be
+  unavailable in shipped builds. That needs a release artifact to check. It is a real question and
+  it is deliberately out of scope here, because "run the tests" and "fix distribution" are different
+  changes with different risk.
+- Once the job exists, adding `go build` for the release matrix is a small increment on it.
+- Reviewer trap: a green `sidecar` job on first run proves the job exists, not that it works. Step 3
+  is the proof.

--- a/audit-plans/opus-5/004-unify-cli-and-studio-conversion.md
+++ b/audit-plans/opus-5/004-unify-cli-and-studio-conversion.md
@@ -1,0 +1,258 @@
+# Plan 002: Make the CLI convert every kind the studio converts
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: 4
+- Category: correctness, architecture
+- Effort: S
+- Risk: LOW
+- Depends on: nothing
+- Planned at: `80451e6`, 2026-07-24
+- Finding: F-02 (MEDIUM; lowered from HIGH by adversarial review, see AUDIT.md)
+
+## Outcome
+
+`hoplight convert in.json out.json --to rolecall-preset` succeeds for preset and regex sets, exactly
+as the studio already does. `convertFile` becomes the single conversion service both the CLI and the
+studio compose, which is what `src/convert.ts:10` already claims. The kind-mismatch error stops
+saying "different entity kinds" about two entities of the same kind.
+
+## Why this matters
+
+Nine adapters that `docs/FORMAT-SUPPORT.md:53-70` advertises (4 preset, 5 regex) cannot be reached
+from the CLI, so batch or scripted migration of presets and regex sets is impossible while the GUI
+does it without complaint. Worse, the failure message is false. A user converting a SillyTavern
+preset to a RoleCall preset is told these are "different entity kinds" when both are `preset`. That
+message cannot be acted on, because it describes a condition that is not the real one.
+
+## Proven root cause
+
+Live-proven at `80451e6`, same entity and target, same process:
+
+```
+STUDIO  /api/export  sillytavern-preset -> rolecall-preset
+  HTTP 200, wrote 2867 chars as .json
+
+CLI     convertFile  sillytavern-preset -> rolecall-preset
+  FAILED: convert: cannot convert a preset to a preset (different entity kinds)
+```
+
+Two implementations of one operation:
+
+```ts
+// src/convert.ts:143-160 - explicit per-kind branches, three of five kinds
+if (src.kind === "character" && target.kind === "character") { ... }
+if (src.kind === "lorebook"  && target.kind === "lorebook")  { ... }
+if (src.kind === "persona"   && target.kind === "persona")   { ... }
+throw new Error(`convert: cannot convert a ${src.kind} to a ${target.kind} (different entity kinds)`);
+```
+
+```ts
+// src/ui/server-engine.ts:158-178 - mismatch check, then a generic path for every other kind
+if (entity.kind !== target.kind) return err(`cannot write a ${entity.kind} as ${target.id} ...`);
+if (target.kind === "character" && entity.kind === "character") { out = emitBundle(...); }
+else { out = (target.fromCanonical as (e: AnyEntity) => {...})(entity); }
+```
+
+The studio branch is the more capable one and is already proven in production. The CLI path
+enumerates kinds and was not extended when preset and regex adapters were added.
+
+`src/cli.ts:363` is the only CLI call site; it surfaces the thrown message verbatim at `:367`.
+
+## Current architecture and authority
+
+`convertFile` is the intended single service. Its own docblock, `src/convert.ts:10`, states the
+invariant this plan restores: "Studio inspect/export must compose the same service as the CLI."
+
+The `FormatAdapter` union is discriminated on `kind` (`src/core/adapter.ts`), which is why the
+existing code checks both sides against a literal: it narrows each adapter to its member so no cast
+is needed. That is a deliberate type-safety decision and the reason the generic path in
+`server-engine.ts:173` needs its `as` cast. Preserve the narrowing where it buys safety; confine the
+cast to one place.
+
+Bundle behavior that must not regress:
+
+- character: `inspectBundle` extracts an embedded book and sets `knowledgeRefs`, `emitBundle`
+  re-embeds via `EmitContext` (`src/convert.ts:47-104`).
+- preset: `inspectPresetBundle` (`src/convert.ts:74-83`) pulls bundled regex via `extractRegex`,
+  implemented by `src/formats/rolecall/preset.ts:171` and `src/formats/sillytavern/preset.ts:72`.
+  It exists and is tested but no CLI route reaches it.
+
+## Target architecture
+
+One generic same-kind path, with character keeping its bundle special case:
+
+```ts
+export function convertFile(
+  src: FormatAdapter,
+  target: FormatAdapter,
+  input: AdapterInput,
+  opts?: { requestedExtension?: string },
+): ConvertResult {
+  if (src.kind !== target.kind) {
+    throw new Error(
+      `convert: cannot convert a ${src.kind} to a ${target.kind} (different entity kinds)`,
+    );
+  }
+  if (src.kind === "character" && target.kind === "character") {
+    const { entity, lorebooks } = inspectBundle(src, input);
+    return { out: emitBundle(target, entity, lorebooks, opts?.requestedExtension), lorebooks };
+  }
+  const parsed = parseCanonicalEntity(src.toCanonical(input));
+  if (parsed.kind !== src.kind) {
+    throw new Error(`convert: ${src.id} returned a ${parsed.kind}, expected a ${src.kind}`);
+  }
+  const emit = target.fromCanonical as (e: typeof parsed) => AdapterOutput;
+  return { out: reportedOutput(target, parsed, emit(parsed)), lorebooks: [] };
+}
+```
+
+Two behavior changes beyond reachability, both deliberate:
+
+1. The mismatch guard moves to the top, so its message is only ever emitted when the kinds actually
+   differ. The false "different entity kinds" for same-kind pairs becomes impossible.
+2. The wrong-kind-returned check reports which adapter misbehaved and what it returned, replacing
+   three near-identical hand-written strings.
+
+Then `handleExport` composes the service instead of duplicating dispatch, which is the part that
+actually restores the `src/convert.ts:10` invariant. Its extra responsibilities (resolving
+`knowledgeRefs` from the store, the 422 for missing refs) stay in `server-engine.ts`; only the
+emit dispatch is delegated.
+
+## Files
+
+### Modify
+- `src/convert.ts`: `convertFile` (`:136`). Replace the three-branch body as above. Keep
+  `inspectBundle`, `inspectPresetBundle`, `emitBundle`, `reportedOutput`, and
+  `rewriteKnowledgeRefs` unchanged.
+- `src/ui/server-engine.ts`: `handleExport` (`:150`). Replace the inline `else` cast at `:173` with
+  a call into the shared service. Preserve the `resolveLorebooksFromStore` path and the 422.
+- `src/convert.test.ts`: extend. It already has a cross-kind refusal case; keep it and add same-kind
+  preset and regex cases.
+- `docs/reference/` page for the CLI convert surface: state that all five kinds convert.
+
+### Do not touch
+- `src/cli.ts`: no change needed. `:363` already calls `convertFile` and surfaces the message. If
+  you find yourself editing the CLI, the fix is in the wrong layer.
+- Any `src/formats/**` adapter mapping. This plan changes routing only.
+- `src/entities/runtime-schema.ts`: F-03 owns validation. Do not widen schemas here.
+
+## API and compatibility
+
+No wire or storage contract changes. `/api/export` request and response shapes are unchanged; only
+its internal dispatch moves. Conversions that worked before must produce byte-identical output
+after, which the existing round-trip suites already assert.
+
+`pack` is a registered entity kind (`src/entities/runtime-schema.ts`) with zero adapters. The
+generic path must not make it appear supported: with no pack adapter registered, no pack conversion
+can be requested, and `registry.get()` returns undefined. Add a test asserting that stays true.
+
+## Implementation steps
+
+### Step 1: Red first, at the public boundary
+
+Add to `src/convert.test.ts`, before touching `src/convert.ts`:
+
+- `sillytavern-preset` -> `rolecall-preset` produces non-empty output with a serialize report.
+- `sillytavern-regex` -> `rolecall-regex` likewise.
+- a genuine cross-kind pair (character -> lorebook) still throws, and the message contains
+  "different entity kinds".
+
+Verify: `bun test src/convert.test.ts` -> the two new same-kind cases FAIL with
+"cannot convert a preset to a preset (different entity kinds)". Record that output verbatim; it is
+the honest RED. The cross-kind case must pass already.
+
+### Step 2: Rewrite the dispatch
+
+Apply the `convertFile` body from Target architecture.
+
+Verify: `bun test src/convert.test.ts` -> all pass, including the unchanged cross-kind expectation
+from step 1. Do not modify that assertion.
+
+### Step 3: Delegate the studio path
+
+In `handleExport`, replace the `:173` cast with a call into the shared service so both callers run
+one code path.
+
+Verify: `bun test src/ui/server-bundle.test.ts src/ui/server.test.ts` -> pass.
+
+### Step 4: Guard the empty-kind case
+
+Add a test asserting a kind with no registered adapters cannot be requested through either path.
+
+Verify: `bun test src/convert.test.ts` -> pass.
+
+### Step 5: Live journey
+
+```bash
+bun run hoplight -- convert samples/sillytavern/presets/plain.preset.json \
+  --to rolecall-preset /tmp/out-preset.json
+```
+
+Verify: exit 0, `/tmp/out-preset.json` non-empty and valid JSON, and the printed serialize report
+lists carried and escrowed fields. Then re-import it:
+`bun run hoplight -- inspect /tmp/out-preset.json` -> detects `rolecall-preset`, kind `preset`.
+
+### Step 6: Full wall
+
+Verify: `bun run verify:ci` -> EXIT 0.
+
+## Test plan
+
+- Baseline: `bun run verify:ci` green at `80451e6`.
+- Honest RED: step 1, recorded verbatim.
+- Unchanged GREEN: the same assertions from step 1 pass after step 2, unedited.
+- Named cases: preset same-kind convert; regex same-kind convert; cross-kind still refused;
+  wrong-kind-returned message names the adapter; no-adapter kind unreachable.
+- Exemplar: `src/convert.test.ts` existing cross-kind refusal case.
+- Adjacent: `bun run test:m1`, `bun test src/ui/server-bundle.test.ts`, `bun test src/formats`.
+- Broad: `bun run verify:ci`.
+
+## Documentation and operations
+
+- Update the `docs/reference/` CLI page to state that all five kinds convert, replacing any text
+  that implies characters and lorebooks only.
+- `docs/FORMAT-SUPPORT.md` is generated; re-run `bun run matrix` only if adapter metadata changed.
+  It should not have.
+
+## Done criteria
+
+- `bun run verify:ci` -> EXIT 0.
+- The step 5 live journey succeeds and the output re-imports.
+- `hoplight convert` on a preset no longer prints "different entity kinds".
+- The cross-kind refusal test is byte-identical to what step 1 wrote.
+- `src/ui/server-engine.ts` no longer contains its own `fromCanonical` dispatch cast.
+- No files outside the Files section changed.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- A preset or regex adapter throws inside `fromCanonical` once reachable. That is a latent adapter
+  bug this plan merely exposed. Stop and report it as a new finding; do not patch the adapter here.
+- Any existing character or lorebook conversion changes its output bytes. The generic path must be
+  behavior-preserving for kinds that already worked.
+- `handleExport` delegation would require moving `resolveLorebooksFromStore` into `src/convert.ts`.
+  That would pull studio storage into the app layer and invert the dependency direction. Stop and
+  re-plan.
+- The `as` cast cannot be confined to one site without weakening the discriminated union's
+  guarantees elsewhere.
+
+## Rollback and recovery
+
+Pure routing change, no persisted state. Revert the two source files and the test additions.
+Anything converted with the new path remains valid, since the output is produced by the same adapter
+`fromCanonical` the studio already used.
+
+## Maintenance notes
+
+- The reason this bug existed is that a *list of kinds* was duplicated in two places. The fix
+  removes the list. If a future change reintroduces per-kind branching in either caller, it
+  reintroduces this class of bug.
+- Reviewer trap: it is tempting to "fix" this in `src/cli.ts` by special-casing presets. That leaves
+  the two implementations divergent and the invariant still broken.
+- When a `pack` adapter eventually ships, it should need zero changes here. If it does need changes,
+  the generic path was not generic enough.

--- a/audit-plans/opus-5/005-close-canonical-validation-gap.md
+++ b/audit-plans/opus-5/005-close-canonical-validation-gap.md
@@ -1,0 +1,269 @@
+# Plan 003: Close the canonical validation gap and make schema drift impossible
+
+> Executor contract: Read the entire plan. Follow steps in order. Run every
+> verification gate. Touch only in-scope files. Stop on any STOP condition.
+> Report deviations instead of silently improvising.
+
+## Status
+
+- Priority: 5
+- Category: correctness, data
+- Effort: M
+- Risk: MEDIUM (tightening a validation boundary can reject data that currently round-trips)
+- Depends on: nothing
+- Planned at: `80451e6`, 2026-07-24
+- Finding: F-03 (MEDIUM; lowered from HIGH and the security framing withdrawn by adversarial
+  review, since no untrusted actor can reach the boundary. See AUDIT.md)
+
+## Outcome
+
+Every field the canonical model declares is validated at the storage and HTTP boundary, and a future
+change that adds a field to the TypeScript interface without adding it to the runtime schema fails a
+gate instead of shipping silently.
+
+## Why this matters
+
+`CLAUDE.md:57` states that `src/entities/runtime-schema.ts` validates at the storage and HTTP
+boundaries and that TS interfaces are never runtime validation. That is true for 11 of the 16
+top-level fields of `CharacterBody`. It is not true for `behavior`, `bias`, `presentation`,
+`settings`, or `variants`.
+
+Live-proven at `80451e6`: an entity carrying shapes the interfaces forbid outright was accepted and
+persisted verbatim.
+
+```
+runtime-schema safeParse -> ok=true
+POST /api/studio/save    -> HTTP 200 ACCEPTED
+
+Read back from disk:
+  variants      = "not-an-array-at-all"      (declared CharacterVariant[])
+  behavior      = {"conditions":12345,...}   (declared CharacterBehavior)
+  presentation  = [1,2,3]                    (declared Presentation)
+  settings      = "a string where an object belongs"
+  bias          = {"logitBias":"should-be-structured"}
+```
+
+`variants` and `behavior` drive real editor features. A consumer doing `body.variants.map(...)`
+throws on a string, with no useful error, and `AGENTS.md` rule 8 ("untrusted input is parsed once
+into a known type; anything unreadable is rejected at the boundary") is not upheld at the boundary
+the docs name.
+
+Being precise about what this is **not**: `z.looseObject` passes unknown keys through by design, so
+nothing is silently dropped and escrow is unaffected. Sealed-script rules still prevent execution of
+card payloads. This is a data-integrity and fail-closed problem, not a demonstrated escalation path.
+
+## Proven root cause
+
+The canonical shape is defined **twice**, by hand, in two files that reference each other not at all:
+
+- `src/entities/character/schema.ts` declares roughly twenty `export interface` types
+  (`Identity:14`, `Voice:41`, `Persona:75`, `Prompts:104`, `Media:192`, `Presentation:226`, and so
+  on). It imports no zod and derives nothing.
+- `src/entities/runtime-schema.ts:37` independently rebuilds the same shapes as zod `looseObject`s.
+
+This directly contradicts the stated convention. `docs/03-CONVENTIONS.md:10`: "zod schemas are the
+single source of truth for shapes; TS types derive via [z.infer]". `CLAUDE.md:104` repeats it: "no
+duplicate interfaces".
+
+Two hand-maintained definitions of one shape drift. They have. Measured: `CharacterBody` has 16
+top-level fields, `characterBodySchema` describes 11.
+
+The control that should have caught it does not cover it. `src/ui/switch/storage-shape-tripwire.test.ts`
+hashes exactly three files:
+
+```ts
+const SHAPE_FILES = [
+  "src/entities/runtime-schema.ts",
+  "src/studio/settings-shape.ts",
+  "src/core/canonical.ts",
+];
+```
+
+`src/entities/*/schema.ts` is absent, so a persisted-shape change made in the interfaces does not
+trip the wire. Note the tripwire itself is a good control, well documented, and works as designed
+for the files it does cover; its scope is the gap, not its logic.
+
+The same duplication exists for `lorebook`, `persona`, `preset`, `regex`, and `pack`. Only the
+character drift was measured. The others are unmeasured and plausible.
+
+## Current architecture and authority
+
+- Canonical authority for validation: `parseCanonicalEntity` / `safeParseCanonicalEntity`
+  (`src/entities/runtime-schema.ts:260,265`) over `canonicalEntitySchema:248`, a
+  `z.discriminatedUnion("kind")` across all six kinds.
+- Call sites: `src/ui/server-engine.ts:153` (`/api/export`), `src/ui/server-studio-write.ts`
+  (`/api/studio/save`), `src/convert.ts:51,78,149,155`, and `src/studio/store.ts`.
+- `z.looseObject` is a deliberate choice consistent with the escrow philosophy: unknown keys survive
+  rather than being stripped. Preserve that. The goal is to **describe** the declared fields, not to
+  start rejecting unknown ones.
+
+## Target architecture
+
+One source of truth for each canonical shape, with drift caught by a gate rather than by review.
+
+Step 1 is a bounded investigation because the source evidence does not by itself determine which of
+three safe shapes is right, and guessing here would be expensive to undo.
+
+### Decision table for step 1
+
+| Option | What it is | Cost | Risk | Choose when |
+| --- | --- | --- | --- | --- |
+| A. Type-level parity assertion | Keep both definitions; add a compile-time mutual-assignability check between `CharacterBody` and `z.infer<typeof characterBodySchema>` so `bun run typecheck` fails on drift | S | LOW | The `looseObject` catchall infers cleanly enough for mutual assignability |
+| B. Derive interfaces from zod | Delete the hand-written interfaces; export `z.infer` aliases. Matches the stated convention exactly | L | MEDIUM | A is not expressible, and the churn across `src/formats/**` consumers is acceptable |
+| C. Runtime key-set parity test | A test asserting the zod schema's key set equals a pinned list per kind | S | LOW | A and B both blocked; weakest option, catches only top-level drift |
+
+Prefer A. It satisfies the convention's intent (one checked relationship), costs the least, and
+turns drift into a typecheck failure without touching any consumer. Fall back to C only if both A
+and B are blocked, and say so explicitly in the PR.
+
+Whichever is chosen, the five missing subtrees get described in zod, and `SHAPE_FILES` grows to
+cover the files that define persisted shape.
+
+## Files
+
+### Modify
+- `src/entities/runtime-schema.ts`: add schemas for `behavior`, `bias`, `presentation`, `settings`,
+  `variants` to `characterBodySchema:37`. Use `z.looseObject` throughout to preserve pass-through.
+  Mark each `.optional()` to match the interface.
+- `src/ui/switch/storage-shape-tripwire.test.ts`: extend `SHAPE_FILES` with every
+  `src/entities/*/schema.ts`, then update `PINNED_SHAPE_HASH`. Read that file's header first; it
+  documents exactly when a hash update alone is correct and when `SCHEMA_BUMPS` must also grow.
+- `src/entities/character/schema.ts`: only under option B.
+
+### Create
+- `src/entities/schema-parity.test.ts` (option A or C): the drift gate. Exemplar
+  `src/formats/_shared/platform-parity.test.ts`, which is the repo's existing parity-gate pattern.
+
+### Do not touch
+- `src/formats/**`: adapters write these fields today and must keep working. If an adapter emits a
+  shape the new schema rejects, that is a finding, not a schema to loosen. See STOP conditions.
+- Escrow (`original`) handling anywhere. Untouched by this plan.
+- `SCHEMA_BUMPS` in `src/ui/_shared/switch-decision.ts`: this plan describes existing on-disk shape
+  more accurately; it does not change it. Adding an entry would falsely warn users on rollback.
+  See STOP conditions for when that judgement flips.
+
+## Data and migration
+
+No migration. This plan changes **validation**, not stored shape. `CANONICAL_SCHEMA_VERSION` stays
+`"1"`.
+
+The compatibility question that matters: pieces already on disk were written without validation of
+these five subtrees. Tightening the schema could make an existing, previously loadable piece fail to
+load, which would be a regression worse than the finding. Step 3 exists to prove that does not
+happen, and its failure is a STOP condition.
+
+## Implementation steps
+
+### Step 1: Decide the parity mechanism
+
+Prototype option A: express mutual assignability between `CharacterBody` and
+`z.infer<typeof characterBodySchema>`. Confirm whether `looseObject`'s inferred catchall and the
+optional-versus-required distinctions permit a clean check. Record the result and the chosen option
+in the PR.
+
+Verify: `bun run typecheck` -> clean with the prototype in place, and deliberately renaming one
+interface field makes it FAIL. If the deliberate break does not fail, option A is not viable; fall
+back per the decision table.
+
+### Step 2: Describe the five missing subtrees
+
+Add `behavior`, `bias`, `presentation`, `settings`, `variants` to `characterBodySchema`, mirroring
+`src/entities/character/schema.ts` (`CharacterBehavior`, `Presentation:226`, `CharacterSettings`,
+`CharacterVariant`). Keep `z.looseObject` so unknown keys still pass.
+
+Verify: `bun run typecheck` -> clean. `bun test src/entities` -> pass.
+
+### Step 3: Prove no existing piece breaks
+
+This is the regression that would matter most. Round-trip every fixture in `samples/` through
+`parseCanonicalEntity` and assert every one still parses. Then convert each `samples/` character
+through its own adapter and re-validate.
+
+Verify: `bun run test:m1` and `bun test src/formats` -> pass, with zero new parse failures. Any
+failure here is a STOP condition, not a schema to loosen.
+
+### Step 4: Red test for the actual finding
+
+Add a test asserting the audit's exact probe is now **rejected**: an entity with
+`variants: "not-an-array-at-all"`, `behavior.conditions: 12345`, `presentation: [1,2,3]`,
+`settings: "a string"`, `bias.logitBias: "should-be-structured"` must fail
+`safeParseCanonicalEntity`, and `POST /api/studio/save` must return 400.
+
+Verify: `bun test src/entities src/ui/server.test.ts` -> pass. Confirm this test FAILS against
+`80451e6` before step 2, which is the honest RED.
+
+### Step 5: Install the drift gate
+
+Add the parity check chosen in step 1.
+
+Verify: temporarily add a field to `CharacterBody` without adding it to zod. `bun run typecheck`
+(option A) or `bun test src/entities/schema-parity.test.ts` (option C) -> FAILS. Revert. Record the
+failure text in the PR.
+
+### Step 6: Widen the storage-shape tripwire
+
+Add every `src/entities/*/schema.ts` to `SHAPE_FILES` and repin `PINNED_SHAPE_HASH`. Read the
+file's header comment first and follow its instruction: this change adds coverage and does not
+change on-disk shape, so the hash updates but `SCHEMA_BUMPS` stays empty.
+
+Verify: `bun test src/ui/switch/storage-shape-tripwire.test.ts` -> pass. Then touch a byte in
+`src/entities/persona/schema.ts` and confirm it FAILS. Revert.
+
+### Step 7: Extend to the remaining kinds
+
+Repeat steps 2 and 5 for `lorebook`, `persona`, `preset`, `regex`, and `pack`. Measure each drift
+before fixing it and record the per-kind field counts in the PR, so the audit's "unmeasured and
+plausible" becomes measured either way.
+
+Verify: `bun run verify:ci` -> EXIT 0.
+
+## Documentation and operations
+
+- If option A or C is chosen, the hand-written interfaces survive, so `docs/03-CONVENTIONS.md:10`
+  and `CLAUDE.md:104` still overclaim ("no duplicate interfaces"). Correct them to describe the
+  checked-parity arrangement actually built. Leaving them as-is reproduces the exact
+  claim-outruns-gate pattern this audit is about.
+- Update the `docs/reference/` page describing canonical validation to list which fields are
+  validated, now that the answer is "all of them".
+
+## Done criteria
+
+- `bun run verify:ci` -> EXIT 0.
+- The step 4 probe is rejected at both `safeParseCanonicalEntity` and `POST /api/studio/save`.
+- The step 5 deliberate drift fails a gate, with the failure output recorded.
+- The step 6 deliberate tripwire touch fails, with output recorded.
+- Every `samples/` fixture still parses and still round-trips.
+- Per-kind field counts for all six kinds recorded in the PR.
+- No files outside the Files section changed.
+- Independent review returns SHIPPABLE.
+
+## STOP conditions
+
+- **An existing `samples/` fixture stops parsing.** Stop. Either the new schema is wrong or a real
+  data defect exists. Do not loosen the schema to get green and do not edit the fixture.
+- **A shipped adapter emits a shape the new schema rejects.** Stop and report it. That is a
+  separate finding.
+- The five subtrees turn out to be **deliberately** unvalidated for a documented reason in an ADR or
+  spec. Then F-03 is partly wrong; stop and reduce this plan to the tripwire widening and the
+  documentation correction only.
+- Option A and option B both prove unworkable, leaving only the weakest gate. Stop and re-plan
+  rather than shipping a parity check that cannot catch nested drift.
+- Any evidence emerges that on-disk shape actually changes. Then `SCHEMA_BUMPS` must grow and this
+  becomes a release-coordinated change, well outside this plan's risk envelope.
+
+## Rollback and recovery
+
+Validation-only, no migration, no stored-shape change, so rollback is reverting the files. The one
+irreversible hazard is a user who saved a malformed piece before the fix: it was accepted then and
+will be rejected now. Before shipping, confirm the studio surfaces a readable error for an
+unloadable piece rather than failing blank, and if it does not, that is a prerequisite to fix first.
+
+## Maintenance notes
+
+- The bug is not the five fields; it is that two hand-maintained definitions existed at all. Fixing
+  the fields without installing the gate guarantees this recurs.
+- Reviewer trap: making the new subtree schemas `z.any()` would make every test pass while
+  validating nothing. Assert the step 4 probe is genuinely rejected.
+- The tripwire's `SHAPE_FILES` list must grow whenever a new file starts defining persisted shape.
+  That is itself a hand-maintained list with the same failure mode. Consider deriving it from the
+  entities directory.

--- a/audit-plans/opus-5/AUDIT.md
+++ b/audit-plans/opus-5/AUDIT.md
@@ -1,0 +1,414 @@
+# Hoplight systemic audit (Opus 5)
+
+- **Mode:** `audit standard direct` (grumpy-systemic-audit skill)
+- **Commit:** `80451e6` on `Mainstage`, clean tree
+- **Date:** 2026-07-24
+- **Auditor:** Claude Opus 5, conductor-only investigation, agent-assisted adversarial review
+- **Revision:** 2, post-review. Revision 1 contained two findings that adversarial review disproved
+  and that I then disproved myself. Both are retained below as withdrawn entries with the evidence
+  that killed them, because deleting them would misrepresent what this audit actually found.
+
+This was a model benchmark. A Fable 5 session audited the same commit in parallel, in a separate
+worktree and branch. No notes or artifacts were shared, and nothing here was informed by that run.
+
+## Headline
+
+Hoplight is in good shape. `bun run verify:ci` is green at HEAD (2250 pass, 0 fail, 25560 expect()
+calls), the defensive engineering is genuinely strong, and the Round-Trip Law that the project
+leads with **is** enforced by CI, which I verified by breaking it.
+
+This audit found **five MEDIUM defects and three LOW ones**. Three of the five MEDIUMs came from
+leads raised by adversarial review rather than from my own pass. It also over-claimed twice, and the
+corrections are as important as the findings.
+
+## Verification baseline
+
+```
+bun install --frozen-lockfile     195 packages
+bun run verify:ci                 EXIT 0
+  2250 pass, 1 skip, 0 fail, 25560 expect() calls, 239 files
+```
+
+## Findings
+
+| ID | Title | Severity | Confidence | Proof | Status |
+| --- | --- | --- | --- | --- | --- |
+| F-06 | Pygmalion export drops portraits and the honesty report conceals it | MEDIUM | HIGH | live | CONFIRMED (from a reviewer lead) |
+| F-07 | 188 TypeScript files under `src/ui` are never linted | MEDIUM | HIGH | live | CONFIRMED (from a reviewer lead) |
+| F-08 | The sidecar's authorization test suite never runs in CI | MEDIUM | HIGH | live | CONFIRMED (from a reviewer lead) |
+| F-02 | CLI cannot convert presets or regex sets the studio converts | MEDIUM | HIGH | live | CONFIRMED |
+| F-03 | Five character subtrees cross the storage boundary unvalidated | MEDIUM | HIGH | live | CONFIRMED |
+| F-04 | "Loopback only" is inaccurate once LAN access is enabled | LOW | HIGH | live | CONFIRMED, impact corrected |
+| F-01 | No gate compels a *new* adapter to ship round-trip evidence | LOW | HIGH | live | **DOWNGRADED from HIGH** |
+| F-05 | `packagedSwitch` orchestration has no direct test | LOW | HIGH | code-read | **DOWNGRADED from MEDIUM** |
+
+Findings F-06 through F-08 came from leads raised by the adversarial reviewers, not from my own
+pass. Each required **executing** code to confirm, which is precisely the class of defect my
+read-only method was structurally blind to. That the three strongest remaining findings all arrived
+this way is the single most useful thing this audit learned about itself.
+
+### [F-02] CLI cannot convert presets or regex sets the studio converts (MEDIUM)
+
+Live-proven. Identical entity, identical target, same process, opposite outcomes:
+
+```
+detected source adapter: sillytavern-preset (kind=preset)
+
+STUDIO  /api/export  sillytavern-preset -> rolecall-preset
+  HTTP 200, wrote 2867 chars as .json
+
+CLI     convertFile  sillytavern-preset -> rolecall-preset
+  FAILED: convert: cannot convert a preset to a preset (different entity kinds)
+```
+
+Reproduced from the shipped CLI: `hoplight convert samples/sillytavern/presets/plain.preset.json
+--to rolecall-preset out.json` exits 1. Regex behaves identically.
+
+**Evidence.** `src/convert.ts:143-159` branches on character, lorebook, and persona only; preset and
+regex fall through to the throw at `:160`. `src/ui/server-engine.ts:158` rejects only a kind
+*mismatch*, then `:173` casts `target.fromCanonical` to a generic signature for every non-character
+kind, so the studio works. `docs/FORMAT-SUPPORT.md:53-70` advertises 4 preset and 5 regex adapters.
+
+**Two distinct harms.** Nine advertised adapters are unreachable from the CLI, so scripted preset
+and regex migration is impossible while the GUI does it happily. And the error message is
+**factually false**: it tells a user converting a preset to a preset that these are "different
+entity kinds", describing a condition that is not the real one.
+
+**Corrections applied after review.** Severity lowered from HIGH to MEDIUM: the failure is
+fail-closed (clear message, exit 1, nothing written, no corruption, no data loss, no security
+surface), and the flagship surface covers the case. I also overstated the invariant claim: I cited
+`src/convert.ts:10` ("Studio inspect/export must compose the same service as the CLI") as a violated
+rule, but that sentence sits in a docblock about the *bundle* layer. More tellingly,
+`src/convert.ts:72-73` describes `inspectPresetBundle` as "Shared by Studio inspect and any future
+CLI bundle path", which reads as known, deliberately deferred work rather than an oversight. The
+defect is real; the framing was too accusatory.
+
+### [F-03] Five character subtrees cross the storage boundary unvalidated (MEDIUM)
+
+Live-proven. `CLAUDE.md:57` says `src/entities/runtime-schema.ts` validates at the storage and HTTP
+boundaries. It describes 11 of `CharacterBody`'s 16 top-level fields.
+
+```
+runtime-schema safeParse -> ok=true
+POST /api/studio/save    -> HTTP 200 ACCEPTED
+
+read back from disk:
+  variants     = "not-an-array-at-all"      (declared CharacterVariant[])
+  behavior     = {"conditions":12345,"effects":{"nested":{"deeply":[null,null]}}}
+  presentation = [1,2,3]
+  settings     = "a string where an object belongs"
+  bias         = {"logitBias":"should-be-structured"}
+```
+
+Unvalidated: `behavior`, `bias`, `presentation`, `settings`, `variants`.
+
+**Root cause.** The canonical shape is defined twice, by hand.
+`src/entities/character/schema.ts` declares ~20 `export interface` types and imports no zod;
+`src/entities/runtime-schema.ts:37` independently rebuilds them as zod `looseObject`s. This
+contradicts `docs/03-CONVENTIONS.md:10` and `CLAUDE.md:104` ("zod schemas are the single source of
+truth ... no duplicate interfaces"). Two hand-maintained definitions drift, and these have.
+
+The control that might have caught it does not cover it:
+`src/ui/switch/storage-shape-tripwire.test.ts` hashes only `runtime-schema.ts`,
+`settings-shape.ts`, and `canonical.ts`. `src/entities/*/schema.ts` is absent.
+
+**Corrections applied after review.** Severity lowered from HIGH to MEDIUM and the security framing
+**withdrawn**. I demonstrated this through `POST /api/studio/save`, which implies an attacker path
+that does not exist: every `/api/` route is gated by a Host check, an allowlisted loopback Origin,
+and a `timingSafeEqual` comparison against a per-launch 32-byte token, and the trusted server binds
+`127.0.0.1`. Nothing untrusted reaches this boundary. `z.looseObject` also passes unknown keys **by
+design**, consistent with the escrow philosophy, so nothing is dropped. The honest impact is
+data-integrity and fail-closed doctrine: a malformed or hand-edited piece crashes an editor via
+`body.variants.map(...)` on a string, with no useful error.
+
+### [F-04] "Loopback only" is inaccurate once LAN access is enabled (LOW)
+
+`src/ui/remote/lan-server.ts:175` binds `0.0.0.0` (comment at `:169` confirms), against
+`README.md:950` ("The server binds 127.0.0.1 only"), `:125`, `:939`, `:988`, `SECURITY.md:30`,
+`SECURITY.md:48`, and `CLAUDE.md:67`. The process runs four listeners plus a Tailscale sidecar node.
+
+**Corrections applied after review.** Severity lowered from MEDIUM to LOW, and my central impact
+claim was **wrong**. I argued that `SECURITY.md` scopes researchers away from the LAN listener.
+`SECURITY.md:28-30` actually reads "Reports most valuable here:", which is a prioritization, not a
+scope fence, and the document's only explicit exclusion is attackers who already run code on the
+machine. The LAN feature is also documented truthfully under `docs/reference/`, which is where
+`AGENTS.md:84-85` actually binds the docs rule. What remains is a genuine but small wording defect
+in three summary documents. The feature itself is opt-in, TLS-wrapped, argon2id connect-code gated,
+per-IP throttled, and host-approved; the engineering is sound.
+
+### [F-01] No gate compels a *new* adapter to ship round-trip evidence (LOW, downgraded from HIGH)
+
+**Revision 1 claimed the Round-Trip Law is not enforced by CI. That claim was false and I withdraw
+it.** The correction matters more than the residual, so it goes first.
+
+I copied `src/formats/_template` to a real folder with a `fromCanonical` returning empty text and
+observed `verify:ci` pass green, and concluded the Law was unenforced. **The probe was invalid.**
+`_template`'s `detect()` returns `0`; `src/core/registry.ts:10` sets `DETECT_THRESHOLD = 0.5` and
+`:40` returns `undefined` below it. The adapter could never be selected as a source, so it never
+round-tripped anything. Its green run proved nothing.
+
+The correct experiment, which I then ran, disproves the finding. Breaking the escrow re-merge in a
+shipping codec (`src/formats/sillytavern/index.ts:128-133`, replacing the conditional with
+`const base: TavernData = {}`) produced:
+
+```
+1361 pass, 8 fail
+```
+
+CI blocks a deliberately-broken round-trip, which is exactly the `docs/ROADMAP.md` M0 exit criterion
+I claimed was unmet. Roughly 40 named round-trip tests exist across every shipped adapter folder.
+
+Two further errors in revision 1. I quoted the ROADMAP exit line and its JEWEL DONE status while
+omitting the governing "Code reality" clause at `:66-67` that scopes DONE to "tsc + bun test +
+color/line scans", which is precisely the bar I measured as green. And I dismissed
+`src/ui/receipt.test.ts` as "a cosmetic display-name map" when its docblock states it is a
+registry-walking gate that fails on any adapter without a friendly name. It was working as designed
+and it caught my probe.
+
+**The residual, which is real but small:** no gate requires a newly added drop-in adapter to ship
+round-trip evidence of its own, and `specs/formats/escrow-and-roundtrip.md:16-17` still describes a
+`fixtures/<format>/**` auto-discovery harness that does not exist in this tree (a leftover from the
+abandoned `packages/*` layout). `AGENTS.md:69` already frames the Law as fixture-scoped, so the
+current design is deliberate. This is a contributor-discipline nice-to-have plus a stale spec line.
+
+### [F-05] `packagedSwitch` orchestration has no direct test (LOW, downgraded from MEDIUM)
+
+**Revision 1 claimed "the update download and staging path has zero tests". That was materially
+false.** `resolveAsset` and `isAllowedDownloadHost`, the two security-critical guards on that path,
+live in `src/ui/_shared/release-download.ts:13,26` and have a dedicated test file. I asserted
+`packaged-engine.ts` "owns asset resolution"; it does not, it imports it.
+
+**The residual:** `packagedSwitch` itself (`src/ui/switch/packaged-engine.ts:113`) has no direct
+test of its orchestration, specifically the checksum comparison at `:145` and the staging write at
+`:150`. Its logic is correct and fails closed at every branch, which I verified by reading it. Also
+untested: `switch/git-runner.ts`, `switch/setup.ts`.
+
+### [F-06] Pygmalion export silently drops portraits and the honesty report conceals it (MEDIUM)
+
+Live-proven across four samples from three source formats. This is the most user-visible defect in
+the audit and it was found by chasing a reviewer's lead, not by my own pass.
+
+**Evidence.** `src/formats/pygmalion/coverage.ts:17` declares `"media.portrait"` in `carries`.
+`src/formats/pygmalion/index.ts:150-168` `fromCanonical` emits a PNG carrier **only** when
+`entity.original.pygmalion.sourceMedia` exists. It never reads `body.media.portrait`. So a character
+imported from any other format has no pygmalion escrow, falls through to the JSON branch at `:168`,
+and loses its portrait.
+
+`src/core/reports.ts:87` computes the dropped list as everything the target's `CoverageDecl` does
+**not** cover, via `coversPath`. Because `media.portrait` is declared carried, the loss is exempted
+from the report.
+
+```
+samples/backyard/characters/2.byaf              -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/backyard/characters/3.byaf              -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/sillytavern/characters/v3-full.json     -> pygmalion  .json  image=NO  portrait reported dropped? false
+samples/rolecall/characters/vera-casting-card   -> pygmalion  .json  image=NO  portrait reported dropped? false
+```
+
+Each source entity genuinely populates `body.media.portrait`; each output carries no image; none
+reports the loss. **`media.assets` appears in every dropped list**, which proves the reporting
+machinery works correctly and that `media.portrait` alone is being suppressed by the declaration.
+
+**Why this is worse than an ordinary drop.** Hoplight's honesty reporting exists precisely so users
+know what a conversion will cost them. Here it actively asserts a portrait survives when it does
+not. A silent loss with a clean report is worse than a loud loss.
+
+**Note on intent.** `coverage.ts:22` already knows the truth: "PNG carrier pixels when imported from
+a Pygmalion-style chara PNG; not a card key". But `notes` is prose and `carries` is the
+machine-readable claim that `coversPath` consumes unconditionally. The declaration over-claims
+relative to its own note. This is the exact failure mode `src/core/coverage.ts:7-8` warns about when
+it says the harness pinning claims to codec reality is "tracked follow-up work".
+
+**Fix direction.** Either make `fromCanonical` honor `body.media.portrait` when no escrow exists, or
+remove `media.portrait` from `carries` so the report tells the truth. The first is better for users;
+the second is honest immediately. Prefer the first, ship the second first if they must be split.
+
+### [F-07] 188 TypeScript files under src/ui are never linted (MEDIUM)
+
+Live-proven. `AGENTS.md:110` describes `lint:ui` as "eslint on the React shell, zero warnings".
+
+**Evidence.** `package.json:38` globs `"src/ui/**/*.tsx"`, and `eslint.config.mjs:43` **also** scopes
+its `files` key to `src/ui/**/*.tsx`, so this is not merely a CLI glob: eslint has no configuration
+that matches a `.ts` file at all. 188 non-test `.ts` files under `src/ui` are excluded, including
+`api.ts`, `docs-corpus.ts` (path containment), and everything under `_shared/` and `remote/`.
+
+Three of them define React hooks: `src/ui/shell/menus.ts`, `src/ui/apps/workbench/use-variants.ts`,
+`src/ui/apps/workbench/lore/use-marinara-folders.ts`.
+
+**Reproduction.** I planted a conditional `useState` (the violation `eslint.config.mjs:51` calls
+"always an error" because "conditional/looped hooks corrupt React's dispatcher state") into
+`src/ui/apps/workbench/use-variants.ts`:
+
+```
+bun run lint:ui                                     -> EXIT 0, clean
+bunx eslint src/ui/apps/workbench/use-variants.ts   -> "File ignored because no matching configuration was supplied"
+same code copied to a .tsx file                     -> error react-hooks/rules-of-hooks
+bun run verify:ci                                   -> EXIT 0, 2250 pass, 0 fail
+```
+
+The rule works perfectly. The scoping excludes the files. The complete wall ships a
+dispatcher-corrupting hook violation without complaint. Probe reverted.
+
+**Fix direction.** Widen both the `package.json` glob and the `eslint.config.mjs` `files` key to
+`src/ui/**/*.{ts,tsx}`, keeping the JSX-only `no-restricted-syntax` block scoped to `.tsx`. Expect
+an initial backlog of warnings.
+
+### [F-08] The sidecar's entire authorization test suite never runs in CI (MEDIUM)
+
+**Evidence.** No workflow under `.github/workflows/` contains a Go step, and `verify:ci`
+(`package.json:41`) has none either. `sidecar/main_test.go` holds nine tests, and every one of them
+guards the remote-access authorization boundary:
+
+```
+TestProxyDeniesUnidentifiedCaller        TestProxyDeniesNodeWithoutStableID
+TestProxyDeniesNonOwner                  TestDeviceTrackerKick
+TestProxyFailsClosedWhenOwnerUnresolved  TestProxyDeniesKickedDevice
+TestProxyStampsIdentityFromWhoIsNotFromClient
+TestProxyOmitsSecretWhenUnset            TestSecretsEqualConstantTime
+```
+
+Identity spoofing prevention, non-owner denial, kicked-device enforcement, and constant-time secret
+comparison. None execute in CI. Neither does `go build`, so the sidecar is not even compile-checked.
+
+**Limitation, stated honestly.** The Go toolchain is not installed on this machine, so I could not
+run the suite to confirm it currently passes. What is verified is that CI never runs it.
+
+**Unresolved secondary observation.** `release.yml` builds only through `scripts/build-desktop.ts`,
+which contains no sidecar reference, and `sidecar/build.ts` documents itself as a manual step
+("Run: `bun sidecar/build.ts`"). `src/ui/server-remote.ts:27` says a missing binary "fails soft".
+Whether official release artifacts actually contain a sidecar binary is **not determined** here; it
+would need a release artifact to check. Flagging rather than guessing.
+
+## Systemic theme: withdrawn, then re-established on different evidence
+
+Revision 1 proposed: "Hoplight's documented guarantees are consistently stronger than the gates that
+enforce them." I **withdrew** it, correctly, because it rested on F-01 and F-05 and both collapsed.
+A reviewer called it "a compliment wearing a finding's clothes" and was right about the version I
+had built.
+
+Chasing the reviewers' leads then produced three confirmed instances that do hold, each proven by
+execution:
+
+| Claim | Where stated | Reality |
+| --- | --- | --- |
+| `media.portrait` is carried by the Pygmalion codec | `src/formats/pygmalion/coverage.ts:17` | Dropped for every non-Pygmalion source, and the loss report suppresses it (F-06) |
+| "eslint on the React shell, zero warnings" | `AGENTS.md:110` | 188 `.ts` files under `src/ui` have no matching eslint config (F-07) |
+| `verify:ci` is "the whole wall" | `AGENTS.md:93`, `CLAUDE.md:19` | No Go step, so nine authorization tests never run (F-08) |
+
+Add F-03 (`CLAUDE.md:57` says the boundary is validated; five fields are not) and F-04 (docs say
+loopback only; a `0.0.0.0` listener exists) and the theme stands on five independent instances
+rather than two bad ones.
+
+So the honest verdict is the one the completeness critic reached: **the theme is right, for reasons
+this audit did not originally find.** I reached the correct conclusion through two invalid probes,
+which is not the same as being right, and the corrected version is only trustworthy because the
+review process forced the re-derivation.
+
+The counter-evidence still deserves weight, because it is real and it bounds the theme: this
+codebase repeatedly documents its own weaknesses rather than overclaiming.
+`src/core/coverage.ts:5-8` volunteers that coverage claims are unpinned, which is exactly the gap
+F-06 exploits. `src/ui/server-security.ts:45-49` explains why the loopback host gate is deliberately
+permissive. `src/ui/switch/storage-shape-tripwire.test.ts` exists specifically to stop a control
+from silently falling behind. The pattern is not dishonesty; it is a fast-moving project whose
+summary documents and gate globs lag its code. That distinction should shape the fix: widen the
+gates, do not rewrite the culture.
+
+## Rejection ledger
+
+| Candidate | Verdict |
+| --- | --- |
+| `SCHEMA_BUMPS` empty makes the rollback guard inert | REJECTED, by design. `CANONICAL_SCHEMA_VERSION` has never moved, and the storage-shape tripwire forces a deliberate decision on any change. A good control. |
+| Zip-slip / archive path traversal | REJECTED. No on-disk archive extraction exists anywhere; entries are in-memory map keys. Independently confirmed during review, which traced every `unzipBounded` consumer and every filesystem write in `src/`. |
+| Files near the 500-line cap | NOT A DEFECT. `scan:lines` is a live gate; proximity to a cap is not a defect. |
+| `pack` kind with zero adapters | NOT WORTH DOING. `scripts/format-matrix.ts:29-39` deliberately renders a zero-adapter kind as an honest "(none yet)" row. |
+| The Round-Trip Law is not CI-enforced | **REJECTED, disproven by experiment.** See F-01. |
+| The update path has zero tests | **REJECTED, disproven.** See F-05. |
+
+## Reviewer leads: chased and resolved
+
+The completeness critic raised four leads. Three were chased to confirmation and promoted to
+findings F-06, F-07, and F-08 above. One could not be reproduced and stays a lead.
+
+| Lead | Outcome |
+| --- | --- |
+| Pygmalion `media.portrait` over-claim | **CONFIRMED** -> F-06, live-proven on 4 samples |
+| `lint:ui` glob excludes `.ts` | **CONFIRMED** -> F-07, live-proven with a planted violation |
+| No Go step in CI | **CONFIRMED** -> F-08 |
+| Archive entry-count DoS | **NOT REPRODUCED**, remains open below |
+
+### Open: archive entry-count DoS (UNREPRODUCED, security-sensitive)
+
+The claim: `fflate` reads a declared entry count from an attacker-controlled zip64 EOCD and loops
+that many times, while `src/core/archive.ts`'s `maxEntries` check sits inside the filter callback
+and so can never terminate the loop. Reported as 967ms from a 98-byte file at 16M declared entries,
+reachable through `registry.detect()` because risu, lumiverse, and byaf each sniff `PK`, and
+blocking the event loop because `unzipSync` is synchronous.
+
+**I could not reproduce it.** My crafted zip64 EOCD threw `ArchiveLimitError` in 2-5ms with no
+scaling at all:
+
+```
+declared=   1,000,000  bytes=98  5ms  -> ArchiveLimitError
+declared=   4,000,000  bytes=98  2ms  -> ArchiveLimitError
+declared=  16,000,000  bytes=98  2ms  -> ArchiveLimitError
+```
+
+Flat, not linear, which is the opposite of the reported measurement. The most likely explanation is
+that my header craft is wrong and fflate rejects it before reaching the zip64 central-directory
+path, so this is evidence about my probe rather than about the code.
+
+**Status: open.** It is not a finding and must not be reported as one. If pursued, it should be
+investigated against fflate's actual zip64 parsing and handled privately per `SECURITY.md`, since a
+confirmed result would be a remote-triggerable denial of service on every listener at once.
+
+## Coverage: what was and was not audited
+
+**Audited with call-path depth:** `src/convert.ts`; `src/core/` canonical model, registry, loader,
+archive, coverage; `src/entities/` schemas and runtime validation; `src/ui/server*.ts` route table
+and security context; `src/studio/` path policy, atomic writes, store; `src/ui/switch/` update and
+rollback; `src/formats/` adapter contract, registration, and escrow sites; CI workflows; the root
+instruction and policy documents.
+
+**Not audited in depth:** `src/ui/` React shell and the 8 apps (489 of 829 files); sandbox
+adversarial testing; per-adapter mapping fidelity (66 files); `sidecar/` internals; the
+`scripts/audit/` UI harness; performance and capacity entirely; accessibility; any live browser
+journey.
+
+**Honest assessment of scale.** Five findings across 829 files is roughly one per 166 files, and
+about 60-70% of the codebase was never examined. The severity distribution (0 CRITICAL, 0 HIGH after
+correction, 5 MEDIUM, 3 LOW) has no long tail of LOWs, which real sweeps produce. Read this as a
+scoping pass over roughly a third of the repository, not as a verdict on it.
+
+**Method limitation, stated plainly, and then partly corrected.** None of my five original findings
+required executing the code; all were legible from structure alone. That is the finding-shape a
+read-only pass produces, and it explains why my first systemic theme was partly an artifact of
+method rather than a property of the code.
+
+The correction is the most instructive result here. Every one of the three strongest findings
+(F-06, F-07, F-08) came from a reviewer's lead and required **running** something to confirm: four
+adapter exports for F-06, a planted lint violation for F-07, a workflow and test-suite enumeration
+for F-08. F-06 in particular took two attempts, because my first probe used a source entity that
+did not populate `media.portrait` at all and proved nothing, the same class of error that sank F-01.
+
+Running `direct` (no shards) on a 102k-line repository concentrated depth on authority boundaries
+and left breadth surfaces untouched. A sharded pass with a mandate to execute rather than read would
+find more, and different, defects, and `src/ui` (489 files), per-adapter fidelity (66 files), and
+the sandbox remain the places to point it.
+
+## Reviewer verdicts
+
+Sixteen independent fresh-context reviewers, three lenses per finding (evidence accuracy, by-design
+check, impact realism) plus one completeness critic. Each was given the raw repository instructions,
+the raw finding, and the source, and told to assume the finding was wrong. None saw a preferred
+verdict.
+
+| Finding | Refuted | Conductor action |
+| --- | --- | --- |
+| F-01 | 3/3 | Withdrawn as stated, re-verified myself, downgraded to LOW |
+| F-02 | 0/3 | Severity HIGH -> MEDIUM, invariant claim softened |
+| F-03 | 1/3 | Severity HIGH -> MEDIUM, security framing withdrawn |
+| F-04 | 1/3 | Severity MEDIUM -> LOW, impact claim corrected |
+| F-05 | 3/3 | Withdrawn as stated, downgraded to LOW |
+
+Every objection above was verified by me against primary source before being accepted. I did not
+accept the reviewers' conclusions on trust any more than I expected them to accept mine.

--- a/audit-plans/opus-5/README.md
+++ b/audit-plans/opus-5/README.md
@@ -1,0 +1,95 @@
+# Audit plan set: Opus 5
+
+Systemic audit of Hoplight at commit `80451e6`, 2026-07-24, produced by Claude Opus 5 running the
+`grumpy-systemic-audit` skill in `audit standard direct` mode.
+
+Namespaced by model because this was a benchmark: a Fable 5 session audited the same commit in
+parallel, in a separate worktree and branch. No notes or artifacts were shared.
+
+- **Audit record, evidence, corrections, and rejections:** [AUDIT.md](AUDIT.md)
+- **Read the coverage section of AUDIT.md before trusting this set.** Roughly 60-70% of the
+  repository was never examined. This is a scoping pass over about a third of the code.
+
+## Verification baseline
+
+`bun run verify:ci` at `80451e6`: **EXIT 0**, 2250 pass, 1 skip, 0 fail, 25560 expect() calls.
+Every finding is a gap between a promise and the gate meant to enforce it, not a broken build.
+
+## Findings and plans
+
+Five MEDIUM findings have plans. Three LOW findings are recorded without plans, with rationale.
+
+| Plan | Finding | Title | Priority | Category | Effort | Risk | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [001](001-stop-pygmalion-dropping-portraits.md) | F-06 | Stop Pygmalion export dropping portraits behind a clean report | 1 | correctness, data loss | S | LOW | READY |
+| [002](002-lint-every-ui-typescript-file.md) | F-07 | Lint every TypeScript file under `src/ui` | 2 | tests, delivery | M | LOW | READY |
+| [003](003-run-sidecar-tests-in-ci.md) | F-08 | Run the sidecar's authorization tests in CI | 3 | tests, delivery, security | S | LOW | READY |
+| [004](004-unify-cli-and-studio-conversion.md) | F-02 | Make the CLI convert every kind the studio converts | 4 | correctness, architecture | S | LOW | READY |
+| [005](005-close-canonical-validation-gap.md) | F-03 | Close the canonical validation gap and stop schema drift | 5 | correctness, data | M | MEDIUM | READY |
+
+### Recorded without a plan
+
+| Finding | Severity | Why no plan |
+| --- | --- | --- |
+| F-04: "Loopback only" inaccurate once LAN access is enabled | LOW | A wording fix in three summary documents. Real, but a one-sitting edit that does not need a plan artifact. My original impact claim was wrong and is corrected in AUDIT.md: `SECURITY.md:28-30` reads "Reports most valuable here:", a prioritization rather than a scope fence. |
+| F-01: No gate compels a *new* adapter to ship round-trip evidence | LOW | The Law **is** enforced for shipping codecs, which I verified by breaking one (8 test failures). The residual is contributor discipline plus a stale line at `specs/formats/escrow-and-roundtrip.md:16-17` describing a harness that does not exist. Worth a spec edit, not a plan. |
+| F-05: `packagedSwitch` orchestration has no direct test | LOW | Its security-critical guards (`resolveAsset`, `isAllowedDownloadHost`) **are** tested in `release-download.test.ts`. The residual is the checksum-compare and staging orchestration, plus `git-runner.ts` and `setup.ts`. Ordinary coverage backlog. |
+
+## Execution sequence
+
+Every plan is independent. No two touch the same file, so they can run in parallel by different
+people. Order below is by leverage.
+
+```
+001 pygmalion portraits   (user-facing data loss, smallest fix)
+002 lint coverage         (exposes a backlog; size it before committing)
+003 sidecar CI            (needs a maintainer to add the required status check)
+004 convert unification   (capability gap, fail-closed today)
+005 validation gap        (highest fix risk: tightening a boundary)
+```
+
+| Plan | Primary files |
+| --- | --- |
+| 001 | `src/formats/pygmalion/{index,coverage,pygmalion.test}.ts` |
+| 002 | `eslint.config.mjs`, `package.json`, the `src/ui/**/*.ts` backlog |
+| 003 | `.github/workflows/ci.yml`, `AGENTS.md` |
+| 004 | `src/convert.ts`, `src/ui/server-engine.ts`, `src/convert.test.ts` |
+| 005 | `src/entities/runtime-schema.ts`, `src/ui/switch/storage-shape-tripwire.test.ts` |
+
+Two plans touch `AGENTS.md`/`CLAUDE.md` gate tables (002 and 003). Land one, then rebase the other.
+That is the only cross-plan contact point.
+
+## Reviewer verdicts
+
+Sixteen independent fresh-context reviewers: three lenses per finding (evidence accuracy, by-design
+check, impact realism) plus a completeness critic. Each got the raw repository instructions, the raw
+finding, and the source, and was told to assume the finding was wrong. None saw a preferred verdict.
+
+| Finding | Refuted | Conductor action |
+| --- | --- | --- |
+| F-01 | 3/3 | Withdrawn as stated, re-verified myself, downgraded to LOW, plan deleted |
+| F-05 | 3/3 | Withdrawn as stated, downgraded to LOW, plan deleted |
+| F-02 | 0/3 | HIGH -> MEDIUM, invariant claim softened |
+| F-03 | 1/3 | HIGH -> MEDIUM, security framing withdrawn |
+| F-04 | 1/3 | MEDIUM -> LOW, impact claim corrected |
+
+The completeness critic raised four leads. Three were chased to confirmation and became F-06, F-07,
+and F-08, which are now the three highest-priority plans in this set. The fourth (an archive
+entry-count denial of service) **could not be reproduced** and is recorded in AUDIT.md as an open
+lead, explicitly not a finding.
+
+Every objection was verified against primary source before I accepted it. I did not take the
+reviewers on trust any more than I expected them to take me.
+
+## Updating status
+
+Edit the Status column here and add a dated line to the plan's own Status block. Do not delete
+history: a finding that turns out to be wrong becomes `REJECTED` **with the evidence that killed
+it**. This set already contains two such reversals, and they are the most useful entries in it.
+
+## What this audit did not do
+
+No source changes. `audit` mode is read-only on source; these plans are artifacts, not
+implementations. Nothing has been merged, deployed, or applied. Five throwaway probes were run to
+prove or disprove findings, and every one was reverted; `git status` in the audit worktree shows
+only this directory.


### PR DESCRIPTION
## What this is

A systemic audit of Hoplight at `80451e6`, run with the `grumpy-systemic-audit` skill in
`audit standard direct` mode. Documentation only: it adds `audit-plans/opus-5/` and changes no
source.

**Model disclosure** (per CONTRIBUTING.md): **Claude Opus 5**, conductor-only investigation with a
16-agent adversarial review wave. This was a model benchmark; a Fable 5 session audited the same
commit in parallel in a separate worktree and branch, with no shared notes or artifacts.

## Headline

Hoplight is in good shape. `verify:ci` is green at HEAD (2250 pass, 0 fail, 25560 expect() calls),
the defensive engineering is strong, and the Round-Trip Law the project leads with **is** enforced
by CI, which I confirmed by deliberately breaking a shipping codec (8 test failures).

**Result: 5 MEDIUM, 3 LOW.** Plans for the five MEDIUMs; the three LOWs are recorded with rationale
and no plan.

## Findings

| ID | Finding | Severity | Plan |
| --- | --- | --- | --- |
| F-06 | Pygmalion export drops portraits and the honesty report conceals it | MEDIUM | 001 |
| F-07 | 188 TypeScript files under `src/ui` are never linted | MEDIUM | 002 |
| F-08 | The sidecar's nine authorization tests never run in CI | MEDIUM | 003 |
| F-02 | CLI cannot convert presets or regex sets that the studio converts | MEDIUM | 004 |
| F-03 | Five character subtrees cross the storage boundary unvalidated | MEDIUM | 005 |
| F-04 | "Loopback only" is inaccurate once LAN access is enabled | LOW | none |
| F-01 | No gate compels a *new* adapter to ship round-trip evidence | LOW | none |
| F-05 | `packagedSwitch` orchestration has no direct test | LOW | none |

### The three worth reading first

**F-06 (`src/formats/pygmalion/`)** is the most user-visible. `coverage.ts:17` declares
`media.portrait` carried; `index.ts:150-168` only emits a portrait when Pygmalion's *own* escrow
exists and never reads `body.media.portrait`. Live-proven on four samples across three source
formats: portrait lost, and **not** listed as dropped. `media.assets` is reported dropped in every
one of those runs, which proves the reporting machinery works and that `media.portrait` alone is
being suppressed by the declaration. A silent loss behind a clean report is worse than a loud loss.

**F-07 (`eslint.config.mjs:43`, `package.json:38`)**: both the config `files` key and the npm glob
scope to `.tsx`, so eslint has no configuration matching a `.ts` file. Three of the excluded files
define React hooks. I planted a conditional `useState` in `use-variants.ts`; `lint:ui` and the full
`verify:ci` both passed clean, while the identical code in a `.tsx` file errors on
`react-hooks/rules-of-hooks`.

**F-08 (`.github/workflows/`)**: no Go step anywhere. All nine `sidecar/main_test.go` tests guard the
remote-access authorization boundary (identity spoofing, non-owner denial, kicked devices,
constant-time secret compare) and none of them run. `go build` does not run either, so the sidecar
is not compile-checked.

## This audit corrected itself twice, and that is part of the record

Revision 1 shipped two findings that adversarial review destroyed and that I then disproved myself.
Both are retained in `AUDIT.md` as withdrawn entries with the evidence that killed them.

- **"The Round-Trip Law is not CI-enforced" was false.** My probe copied `_template`, whose
  `detect()` returns `0` against a `0.5` threshold, so the adapter could never be selected and never
  round-tripped anything. The correct experiment, breaking the escrow re-merge in
  `src/formats/sillytavern/index.ts:128-133`, gives 8 failures. I also truncated `docs/ROADMAP.md`
  in a way that inverted its meaning, and dismissed `receipt.test.ts` as cosmetic when it is a
  registry-walking gate that was working as designed.
- **"The update path has zero tests" was materially false.** `resolveAsset` and
  `isAllowedDownloadHost` live in `release-download.ts` and are tested.

Severities on three surviving findings were lowered after review (F-02 and F-03 from HIGH to MEDIUM,
F-04 from MEDIUM to LOW), and F-03's security framing was withdrawn: no untrusted actor can reach
that boundary.

The three strongest findings (F-06, F-07, F-08) came from reviewer leads rather than my own pass,
and each required **executing** code to confirm. That is the honest headline about method.

## Security

Per `SECURITY.md`, which asks for private disclosure first, security detail is **not** in this PR.
No exploitable vulnerability was found. Notes were delivered to the maintainer privately, covering:
the LAN listener versus the "loopback only" wording (F-04, published here because the fix is a docs
edit and there is no exploit attached), ADR-009's packaged-build isolation measurements being
recorded as not run, and a handful of security-relevant modules without direct tests.

One reviewer-raised lead, a possible archive entry-count denial of service, **could not be
reproduced** (flat 2-5ms, no scaling, against a reported 967ms). It is recorded in `AUDIT.md` as an
open lead and explicitly **not** a finding. If pursued it should be handled privately.

## Scope, stated plainly

**Roughly 60-70% of the repository was never examined.** Not audited in depth: `src/ui` (489 of 829
files), per-adapter mapping fidelity (66 files), sandbox adversarial testing, `sidecar/` internals,
performance, accessibility, and any live browser journey.

Running `direct` (no shards) on 102k lines concentrated depth on authority boundaries and left
breadth untouched. None of my five original findings required executing anything; all were legible
from structure alone, which is why the first systemic theme I proposed was partly an artifact of
method. Read this as a scoping pass over about a third of the code, not a verdict on it. A sharded
pass with a mandate to execute would find more, and different, defects.

## Verification

- Baseline at `80451e6`: `bun run verify:ci` EXIT 0, 2250 pass, 0 fail.
- This branch: `bun run verify:ci` EXIT 0. `audit-plans/` sits outside every gate's walk roots, and
  the artifacts hand-honor the no-em-dash and no-emoji conventions anyway.
- Five throwaway probes were run to prove or disprove findings. Every one was reverted; the worktree
  contains only `audit-plans/`.

## For the merger

This is docs-only and should not cut a release. Put **`[skip release]` in the squash or merge commit
message**: `auto-release.yml` reads only the head commit of the push to `Mainstage`, so a marker in
a branch commit is ignored.

Nothing here is implemented. The plans are artifacts, not changes.
