### PR TITLE
fix(formats): stop ST worldbooks importing inert at scan depth zero

### DIFF
--- a/src/core/lore/empty-book.ts
+++ b/src/core/lore/empty-book.ts
@@ -2,6 +2,7 @@
  * Deterministic empty lorebook body factory for "New lorebook".
  */
 import type { LorebookBody, LorebookEntry } from "../../entities/lorebook/schema";
+import { DEFAULT_SCAN_DEPTH } from "../../entities/lorebook/schema";
 
 export function emptyLoreEntry(id: string): LorebookEntry {
   return {
@@ -50,7 +51,7 @@ export function emptyLorebookBody(name = "Untitled lorebook"): LorebookBody {
     enabled: true,
     globalCaseSensitive: false,
     globalMatchWholeWords: false,
-    globalScanDepth: 4,
+    globalScanDepth: DEFAULT_SCAN_DEPTH,
     globalRecursion: false,
     tokenBudget: 0,
     budgetMode: "token",

--- a/src/core/lore/heal.ts
+++ b/src/core/lore/heal.ts
@@ -3,6 +3,7 @@
  * this covers leftovers a tolerant reader may pass through + soft coercions.
  */
 import type { LorebookBody, LorebookEntry } from "../../entities/lorebook/schema";
+import { DEFAULT_SCAN_DEPTH } from "../../entities/lorebook/schema";
 import { emptyLoreEntry, emptyLorebookBody } from "./empty-book";
 
 export interface HealNote {
@@ -164,7 +165,7 @@ export function healBook(raw: unknown): HealResult {
     enabled: root.enabled === false ? false : true,
     globalCaseSensitive: asBool(root.globalCaseSensitive, false),
     globalMatchWholeWords: asBool(root.globalMatchWholeWords, false),
-    globalScanDepth: asNum(root.globalScanDepth ?? root.scanDepth, 4),
+    globalScanDepth: asNum(root.globalScanDepth ?? root.scanDepth, DEFAULT_SCAN_DEPTH),
     globalRecursion: asBool(root.globalRecursion, false),
     tokenBudget: asNum(root.tokenBudget, 0),
     budgetMode: root.budgetMode === "entry" ? "entry" : "token",

--- a/src/entities/lorebook/schema.ts
+++ b/src/entities/lorebook/schema.ts
@@ -253,6 +253,15 @@ export interface LorebookCategory {
 
 export type LorebookType = "world" | "character" | "scenario" | "rules" | "utility" | "other";
 
+/**
+ * House default for `globalScanDepth`, shared by the "New lorebook" factory, heal, and every
+ * importer whose source format leaves scan depth unstated. It is NOT zero on purpose: the
+ * activation engine reads a depth of zero as "scan no lines at all", so a book that lands on
+ * zero matches nothing and reports every entry as no-key-match. A format that genuinely omits
+ * the field means "use the host default", which is this.
+ */
+export const DEFAULT_SCAN_DEPTH = 4;
+
 export interface LorebookBody {
   name: string;
   description?: string | null;

--- a/src/formats/sillytavern/lorebook.test.ts
+++ b/src/formats/sillytavern/lorebook.test.ts
@@ -1,7 +1,11 @@
 /** Regression coverage for the lorebook.test behavior owned beside this file. */
 import { test, expect } from "bun:test";
+import { globSync, readFileSync } from "node:fs";
+import { basename } from "node:path";
 import codec from "./lorebook";
 import rcLorebook from "../rolecall/lorebook";
+import { DEFAULT_SCAN_DEPTH } from "../../entities/lorebook/schema";
+import { scanBook } from "../../core/lore/activation";
 
 /**
  * A standard SillyTavern worldbook: entries as a keyed map, ST int enums (position/role/
@@ -206,4 +210,48 @@ test("canonical bridges an ST worldbook to a RoleCall v1 lorebook export", () =>
   // reconciliation proof: ST `order` (placement) lands in RC placement, NOT RC eviction priority
   expect(out.lorebook.entries[0].priority.sortOrder).toBe(50); // ST order -> RC sortOrder (placement)
   expect(out.lorebook.entries[0].priority.priority).toBe(100); // eviction defaults (ST has no such axis)
+});
+
+/**
+ * Scan depth is the difference between an imported book that matches and one that is inert:
+ * activation reads depth <= 0 as "scan no lines", so an absent ST `scan_depth` must land on the
+ * house default, never on a literal 0. Both shipped ST samples omit the field, and both imported
+ * dead before this was fixed.
+ */
+test("an absent scan_depth imports at the house default, not zero", () => {
+  const book = makeStWorldbook() as Record<string, unknown>;
+  delete book.scan_depth;
+  expect(codec.toCanonical(asText(book)).body.globalScanDepth).toBe(DEFAULT_SCAN_DEPTH);
+});
+
+test("an explicit scan_depth is preserved", () => {
+  const book = { ...makeStWorldbook(), scan_depth: 7 };
+  expect(codec.toCanonical(asText(book)).body.globalScanDepth).toBe(7);
+});
+
+test("a nonsense scan_depth falls back rather than importing inert", () => {
+  for (const bad of [0, -3, null, "4"]) {
+    const book = { ...makeStWorldbook(), scan_depth: bad };
+    expect(codec.toCanonical(asText(book)).body.globalScanDepth).toBe(DEFAULT_SCAN_DEPTH);
+  }
+});
+
+/**
+ * The corpus guard for the whole class: import every shipped ST worldbook, take a keyword out of
+ * the book itself, and assert it actually fires. A unit test on the default alone would not have
+ * caught this, because the bug only shows once the imported depth reaches the activation engine.
+ */
+test("every shipped ST sample worldbook actually matches its own keywords", () => {
+  const files = globSync("samples/sillytavern/lorebooks/*.json");
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    const body = codec.toCanonical({ bytes: readFileSync(file), filename: basename(file) }).body;
+    const keyworded = body.entries.find((e) => e.triggers.length > 0 && !e.constant && e.enabled);
+    if (!keyworded) continue; // a constants-only book has nothing to prove here
+    const keyword = keyworded.triggers[0]?.keyword ?? "";
+    const fired = scanBook(body, [{ text: `talking about ${keyword} right now`, role: "user" }], {
+      chanceMode: "always",
+    }).fired;
+    expect(fired.length).toBeGreaterThan(0);
+  }
 });

--- a/src/formats/sillytavern/lorebook.ts
+++ b/src/formats/sillytavern/lorebook.ts
@@ -19,6 +19,7 @@ import type {
   Trigger,
   InjectionPosition,
 } from "../../entities/lorebook/schema";
+import { DEFAULT_SCAN_DEPTH } from "../../entities/lorebook/schema";
 import { CANONICAL_SCHEMA_VERSION, canonicalId } from "../../core/canonical";
 import { readJsonObject } from "../_shared/card-io";
 import {
@@ -256,7 +257,11 @@ function bookToCanonical(book: StBook): LorebookBody {
     tags: [],
     globalCaseSensitive: book.case_sensitive === true,
     globalMatchWholeWords: book.match_whole_words === true,
-    globalScanDepth: typeof book.scan_depth === "number" ? book.scan_depth : 0,
+    // ST leaves scan_depth absent (or null) to mean "use the host's global setting", so an absent
+    // field must fall back to the house default. Reading it as a literal 0 imported the book inert:
+    // activation treats depth <= 0 as "scan no lines", so every keyword entry reported no-key-match.
+    globalScanDepth:
+      typeof book.scan_depth === "number" && book.scan_depth > 0 ? book.scan_depth : DEFAULT_SCAN_DEPTH,
     globalRecursion: book.recursive_scanning === true,
     tokenBudget: typeof book.token_budget === "number" ? book.token_budget : 0,
     budgetMode: "token",


### PR DESCRIPTION
## The bug

A SillyTavern worldbook that omits `scan_depth` imports with `globalScanDepth: 0`. The activation engine reads a depth `<= 0` as "scan no lines at all" (`activation.ts:50`), so **every keyword entry in the book reports `no-key-match` and nothing ever fires.**

Both shipped ST samples omit the field, so both import dead today:

| sample | entries | keyword placed in chat | fired |
|---|---|---|---|
| `Eorzea-FFXIV.json` | 29 | `Ascians` | **0** |
| `Example-Busy-at-Work.json` | 6 | `busy` | **0** |

Set the depth to 4 and the same books fire 1 and 6 respectively. Constant entries still fire either way, since they never scan, which is part of why this hides: the book looks partly alive.

## Root cause

Two reasonable decisions meeting badly. `sillytavern/lorebook.ts:259` read an absent field as a literal zero:

```ts
globalScanDepth: typeof book.scan_depth === "number" ? book.scan_depth : 0,
```

ST leaves book-level `scan_depth` absent or null to mean "use the host's global setting", not "scan nothing".

## The fix

The house default was already `4` in two places, so this lifts it to a shared `DEFAULT_SCAN_DEPTH` on the lorebook schema and points all three at it:

- `core/lore/empty-book.ts:53` (the New lorebook factory)
- `core/lore/heal.ts:167`
- `formats/sillytavern/lorebook.ts` (new)

A non-positive or non-numeric `scan_depth` now falls back rather than importing inert. An explicit positive depth is preserved untouched.

## Tests

Unit coverage for the absent, explicit, and nonsense cases, plus a corpus guard that imports every shipped ST sample, takes a keyword out of the book itself, and asserts it actually fires.

The corpus test is the one that matters. A unit test on the default alone would not have caught this, because the failure only appears once the imported depth reaches the activation engine. All three new tests fail against current Mainstage.

## Worth your call

Two things I deliberately did not decide:

1. **`4` vs `2`.** I used 4 to match the existing house default. ST's own `world_info_depth` default is 2, so 2 is arguably the more faithful import.
2. **The other importers.** Defaults across the seven lorebook paths are currently `0`, `2`, `4`, and `100`. The zeros in `novelai`, `risu`, `rolecall`, and `agnai` are latent rather than active (NovelAI maps `searchRange` per-entry, which overrides the book-level zero; the Risu and Agnai samples resolve through other paths), so I left them alone rather than widen this PR. Happy to follow up with a pass that collapses them onto the shared constant if you want it.

## Verification

`bun test` full suite green (2840 pass, 0 fail), `tsc --noEmit` clean, `matrix:check` current, `scan:lines` / `scan:emdash` / `scan:emoji` clean.

Written with Claude Opus 5, per the AI-assisted contribution note in CONTRIBUTING.md.