### PR TITLE
fix(formats): keep lorebook entry ids unique so no entry is lost or misfires

### DIFF
--- a/src/formats/_shared/lore-enums.ts
+++ b/src/formats/_shared/lore-enums.ts
@@ -34,3 +34,33 @@ export const parseCharacterFilter = (v: unknown): CharacterFilter | null => {
     tags: Array.isArray(f.tags) ? (f.tags as string[]) : [],
   };
 };
+
+/**
+ * Force entry ids unique, preserving the first claim on any id and suffixing later collisions.
+ *
+ * Formats in this family derive an id from the source file (`uid` in ST, `id` in Marinara) and fall
+ * back to the array index when the field is absent. That fallback collides two ways: a book mixing
+ * uid-bearing and uid-less entries can produce an index that some other entry already claims as its
+ * uid, and `String()` collapses the number 0 and the string "0" onto the same id.
+ *
+ * Duplicates are not cosmetic downstream. The activation engine keys its verdict map by entry id, so
+ * a collision makes one entry inherit the other's verdict and fire on keywords it does not have; and
+ * the ST/Marinara writers index their raw twin by id, so two entries sharing one resolve to the same
+ * output key and the second silently overwrites the first, losing an entry on round-trip.
+ *
+ * Pure, order-preserving, and stable: the same input always yields the same ids.
+ */
+export function ensureUniqueEntryIds<T extends { id: string }>(entries: T[]): T[] {
+  const seen = new Set<string>();
+  return entries.map((entry) => {
+    if (!seen.has(entry.id)) {
+      seen.add(entry.id);
+      return entry;
+    }
+    let suffix = 2;
+    while (seen.has(`${entry.id}-${suffix}`)) suffix += 1;
+    const id = `${entry.id}-${suffix}`;
+    seen.add(id);
+    return { ...entry, id };
+  });
+}

--- a/src/formats/_shared/lore-ids.test.ts
+++ b/src/formats/_shared/lore-ids.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Entry-id uniqueness across the Tavern-family importers, and the two downstream failures a
+ * duplicate used to cause: a false activation verdict and a lost entry on round-trip.
+ */
+import { test, expect, describe } from "bun:test";
+import { ensureUniqueEntryIds } from "./lore-enums";
+import stLorebook from "../sillytavern/lorebook";
+import { scanBook } from "../../core/lore/activation";
+
+const asText = (c: unknown) => ({ text: JSON.stringify(c) });
+
+/** Two ST entries: the first has no uid (so it falls back to index "0"), the second has uid 0. */
+const collidingWorldbook = () => ({
+  name: "Colliding",
+  scan_depth: 5,
+  entries: {
+    "0": { comment: "ALPHA", key: ["alpha"], content: "ALPHA BODY" },
+    "1": { uid: 0, comment: "BETA", key: ["beta"], content: "BETA BODY" },
+  },
+});
+
+describe("ensureUniqueEntryIds", () => {
+  test("leaves already-unique ids untouched, including their order", () => {
+    const input = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(ensureUniqueEntryIds(input).map((e) => e.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("first claim keeps the id; later collisions are suffixed", () => {
+    const got = ensureUniqueEntryIds([{ id: "x" }, { id: "x" }, { id: "x" }]);
+    expect(got.map((e) => e.id)).toEqual(["x", "x-2", "x-3"]);
+  });
+
+  test("a suffix that is itself taken is skipped rather than colliding again", () => {
+    const got = ensureUniqueEntryIds([{ id: "x" }, { id: "x-2" }, { id: "x" }]);
+    expect(got.map((e) => e.id)).toEqual(["x", "x-2", "x-3"]);
+  });
+
+  test("preserves every other field and does not mutate the input", () => {
+    const input = [{ id: "x", title: "one" }, { id: "x", title: "two" }];
+    const got = ensureUniqueEntryIds(input);
+    expect(got[1]).toEqual({ id: "x-2", title: "two" });
+    expect(input[1]!.id).toBe("x"); // input untouched
+  });
+
+  test("is stable: the same input yields the same ids", () => {
+    const run = () => ensureUniqueEntryIds([{ id: "x" }, { id: "x" }]).map((e) => e.id);
+    expect(run()).toEqual(run());
+  });
+});
+
+describe("ST import id collisions", () => {
+  test("a sparse uid no longer collides with another entry's index fallback", () => {
+    const body = stLorebook.toCanonical(asText(collidingWorldbook())).body;
+    const ids = body.entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("only the entry whose keyword is present fires", () => {
+    const body = stLorebook.toCanonical(asText(collidingWorldbook())).body;
+    const result = scanBook(body, [{ text: "alpha appears, nothing else", role: "user" }], {
+      chanceMode: "always",
+    });
+    // Before the fix both entries shared id "0", so BETA inherited ALPHA's verdict and was
+    // reported as fired with reason "key" on a keyword absent from the text.
+    expect(result.fired).toHaveLength(1);
+    const firedTitles = result.fired.map(
+      (v) => body.entries.find((e) => e.id === v.entryId)?.title,
+    );
+    expect(firedTitles).toEqual(["ALPHA"]);
+  });
+
+  test("no entry is lost on round-trip", () => {
+    const entity = stLorebook.toCanonical(asText(collidingWorldbook()));
+    const back = JSON.parse(stLorebook.fromCanonical(entity).text ?? "");
+    const comments = Object.values(back.entries).map((e) => (e as { comment: string }).comment);
+    // Before the fix the two entries resolved to the same output key and ALPHA vanished.
+    expect(Object.keys(back.entries)).toHaveLength(2);
+    expect(comments.sort()).toEqual(["ALPHA", "BETA"]);
+  });
+
+  test("a numeric uid and its string spelling stay distinct entries", () => {
+    const body = stLorebook.toCanonical(
+      asText({
+        name: "Mixed",
+        scan_depth: 5,
+        entries: {
+          "0": { uid: 7, comment: "NUM", key: ["a"], content: "A" },
+          "1": { uid: "7", comment: "STR", key: ["b"], content: "B" },
+        },
+      }),
+    ).body;
+    const ids = body.entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(2);
+    expect(body.entries.map((e) => e.title)).toEqual(["NUM", "STR"]);
+  });
+});

--- a/src/formats/marinara/lorebook.ts
+++ b/src/formats/marinara/lorebook.ts
@@ -43,6 +43,7 @@ import type {
 } from "../../entities/lorebook/schema";
 import { CANONICAL_SCHEMA_VERSION, canonicalId } from "../../core/canonical";
 import { readJsonObject } from "../_shared/card-io";
+import { ensureUniqueEntryIds } from "../_shared/lore-enums";
 
 // -- wire shapes (deserialized storage rows; open bags so unmodelled fields ride the clone untouched) --
 
@@ -221,7 +222,7 @@ function envelopeToCanonical(env: MariEnvelope): LorebookBody {
     globalCaseSensitive: false,
     globalMatchWholeWords: false,
     budgetMode: "token",
-    entries: entries.map(entryToCanonical),
+    entries: ensureUniqueEntryIds(entries.map(entryToCanonical)),
     categories: foldersToCategories(folders),
   };
 }

--- a/src/formats/sillytavern/lorebook.ts
+++ b/src/formats/sillytavern/lorebook.ts
@@ -32,6 +32,7 @@ import {
   parseRole,
   roleToNumber,
   parseCharacterFilter,
+  ensureUniqueEntryIds,
 } from "../_shared/lore-enums";
 
 interface StBook {
@@ -261,7 +262,7 @@ function bookToCanonical(book: StBook): LorebookBody {
     tokenBudget: typeof book.token_budget === "number" ? book.token_budget : 0,
     budgetMode: "token",
     entryBudget: 0,
-    entries: Object.values(entries).map(entryToCanonical),
+    entries: ensureUniqueEntryIds(Object.values(entries).map(entryToCanonical)),
   };
 }
 
@@ -274,10 +275,22 @@ function bookToWire(body: LorebookBody, rawBook: StBook | undefined): StBook {
     twinById.set(id, { key, raw });
   }
 
+  // Never let two entries collapse onto one output key. Imports now guarantee unique ids, but a body
+  // can reach here from storage or another editor, and two entries sharing an id used to resolve to
+  // the same twin key so the second silently overwrote the first: an entry vanished from the export
+  // with no error. A renumbered key is a far smaller loss than a missing entry.
   const entries: Record<string, Record<string, unknown>> = {};
+  const usedKeys = new Set<string>();
   body.entries.forEach((e, index) => {
     const twin = twinById.get(e.id);
-    entries[twin?.key ?? String(index)] = entryToWire(e, twin?.raw);
+    let key = twin?.key ?? String(index);
+    if (usedKeys.has(key)) {
+      let next = body.entries.length;
+      while (usedKeys.has(String(next))) next += 1;
+      key = String(next);
+    }
+    usedKeys.add(key);
+    entries[key] = entryToWire(e, twin?.raw);
   });
 
   return {


### PR DESCRIPTION
## The bug

ST and Marinara derive an entry id from the source file (`uid` / `id`) and fall back to the array index when that field is absent:

```ts
id: raw.uid != null ? String(raw.uid) : String(index),
```

That collides two ways, both plausible in files people actually have:

- **Sparse ids.** An entry lacking `uid` takes its array index. If any other entry has a `uid` equal to that index, they collide. A book where entry 0 has no uid and a later entry has `uid: 0` is enough.
- **Type collapse.** `String()` maps the number `0` and the string `"0"` onto the same id, so a hand-edited book mixing the two collides.

## Two consequences, both silent

**1. An entry is lost on round-trip.** `bookToWire` indexes its raw twin by id, so two entries sharing one resolve to the same output key and the second overwrites the first:

```
canonical entries: 2   ids: ["0","0"]
exported entries:  1   keys: ["1"]
exported comments: ["ALPHA" is gone]
```

Import a colliding book, export it, and an entry has vanished. No error, no warning.

**2. An entry fires on keywords it does not have.** Activation keys its verdict map by entry id, so a collision makes one entry inherit the other's verdict. Isolated against a control, with chat text containing only ALPHA's keyword:

```
CONTROL   ids=["10","11"]  verdicts: 10=true(key) | 11=false(no-key-match)   fired=1  correct
COLLIDING ids=["0","0"]    verdicts: 0=true(key)  | 0=true(key)              fired=2  wrong
```

BETA is reported as fired with reason `key` on a keyword absent from the text, which in prompt assembly means its content gets injected when it should not.

## The fix

Imports run their entries through a shared `ensureUniqueEntryIds` in `_shared/lore-enums.ts`: the first claim keeps the id, later collisions take a numbered suffix, order is preserved, and the pass is stable and pure.

The ST writer separately refuses to reuse an output key. Imports now guarantee unique ids, but a body can reach the writer from storage or another editor, and a renumbered key is a far smaller loss than a missing entry.

`book-ops.ts:14` and `:75` already do this kind of fresh-id reassignment for the merge path, with a comment about two books sharing a category id, so the concern is already understood in the codebase. Import was just missing it.

## Tests

Nine tests: the helper directly (uniqueness, suffix-skipping, field preservation, no input mutation, stability) plus all three downstream symptoms at format level. All four format-level cases fail against current Mainstage.

## Worth your call

I fixed this at the import boundary because ids flow from there into the editor, diff, web graph, and activation, so one guard covers all of them.

Two follow-ups I did not include:

1. **A heal rule.** Books already saved to disk may carry duplicates, and an import-only fix will not repair them.
2. **Hardening activation itself** to key by array index rather than id. That makes the engine robust regardless of which importer produced the body, but it touches `verdictById`, `firedIds`, the budget loop, and the `wokeBy` attribution scan, so it is a real refactor rather than a one-liner. Worth doing only if you want the engine to stop trusting id uniqueness at all.

## Verification

`bun test` full suite green (2783 pass, 0 fail), `tsc --noEmit` clean, `matrix:check` current, style gates clean.

Written with Claude Opus 5, per the AI-assisted contribution note in CONTRIBUTING.md.