### PR TITLE
fix(studio): remove the partial file when an exclusive write fails

### DIFF
--- a/src/studio/atomic-file-cleanup.test.ts
+++ b/src/studio/atomic-file-cleanup.test.ts
@@ -1,0 +1,83 @@
+/**
+ * writeExclusive must not leave a truncated file behind when the write fails AFTER the exclusive
+ * open has already created it.
+ *
+ * Driving that needs a real post-open write error, and no portable filesystem trick summons ENOSPC
+ * or EIO on demand. So one FileHandle.writeFile is armed to throw once, through the handle
+ * prototype, and always restored in a finally plus afterEach. This lives apart from
+ * atomic-file.test.ts so the patch cannot reach the real-filesystem tests there.
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile, writeFile, open, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeExclusive, StudioWriteError, StudioConflictError } from "./atomic-file";
+
+type WriteFileFn = (...args: unknown[]) => Promise<unknown>;
+
+let root: string;
+let handleProto: { writeFile: WriteFileFn };
+let originalWriteFile: WriteFileFn;
+
+const exists = (p: string): Promise<boolean> =>
+  access(p).then(() => true).catch(() => false);
+
+/** Arm exactly one FileHandle.writeFile to fail with ENOSPC, then restore. */
+async function withOneFailingWrite<T>(run: () => Promise<T>): Promise<T> {
+  let armed = true;
+  handleProto.writeFile = async function (this: unknown, ...args: unknown[]) {
+    if (armed) {
+      armed = false;
+      const err = new Error("simulated ENOSPC") as NodeJS.ErrnoException;
+      err.code = "ENOSPC";
+      throw err;
+    }
+    return originalWriteFile.apply(this, args);
+  };
+  try {
+    return await run();
+  } finally {
+    handleProto.writeFile = originalWriteFile;
+  }
+}
+
+describe("writeExclusive cleanup", () => {
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vaude-cleanup-"));
+    const probe = await open(join(root, ".probe"), "w");
+    handleProto = Object.getPrototypeOf(probe) as { writeFile: WriteFileFn };
+    originalWriteFile = handleProto.writeFile;
+    await probe.close();
+  });
+
+  afterEach(async () => {
+    handleProto.writeFile = originalWriteFile; // belt and suspenders; the helper restores too
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("a write that fails after the create leaves no file behind", async () => {
+    const p = join(root, "piece.json");
+    await withOneFailingWrite(async () => {
+      await expect(writeExclusive(p, '{"v":1}')).rejects.toBeInstanceOf(StudioWriteError);
+    });
+    expect(await exists(p)).toBe(false);
+  });
+
+  test("the retry after a failed write succeeds instead of hitting a phantom conflict", async () => {
+    const p = join(root, "piece.json");
+    await withOneFailingWrite(async () => {
+      await expect(writeExclusive(p, '{"v":1}')).rejects.toBeInstanceOf(StudioWriteError);
+    });
+    // Before the fix the orphaned zero-byte file made this throw StudioConflictError forever:
+    // the piece could never be saved under its own name again.
+    await writeExclusive(p, '{"v":2}');
+    expect(JSON.parse(await readFile(p, "utf8"))).toEqual({ v: 2 });
+  });
+
+  test("cleanup never removes a file the call did not create", async () => {
+    const p = join(root, "existing.json");
+    await writeFile(p, '{"mine":true}', "utf8");
+    await expect(writeExclusive(p, '{"v":9}')).rejects.toBeInstanceOf(StudioConflictError);
+    expect(JSON.parse(await readFile(p, "utf8"))).toEqual({ mine: true });
+  });
+});

--- a/src/studio/atomic-file.ts
+++ b/src/studio/atomic-file.ts
@@ -29,16 +29,34 @@ const tmpName = (finalPath: string): string => {
   return join(dir, `.tmp-${tag}.json`);
 };
 
-/** Write bytes to a new exclusive path (fail if exists). */
+/**
+ * Write bytes to a new exclusive path (fail if exists).
+ *
+ * The `wx` open CREATES the file, so a later failure (ENOSPC, EIO, a quota) would otherwise leave a
+ * truncated file sitting at the destination. That is worse than it sounds: the next attempt hits
+ * EEXIST and surfaces as "file already exists" for a piece the user never saved, which both misreads
+ * the situation and blocks the retry that would succeed once space is free. So a write that fails
+ * after creating the file removes it again, matching writeAtomicReplace's temp cleanup.
+ *
+ * The `created` flag is load-bearing: on the EEXIST path the file is someone else's and must NOT be
+ * unlinked, or the cleanup would destroy the very data the exclusive open was protecting.
+ */
 export async function writeExclusive(finalPath: string, body: string): Promise<void> {
   let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let created = false;
   try {
     handle = await open(finalPath, "wx");
+    created = true;
     await handle.writeFile(body, "utf8");
     await handle.sync();
   } catch (e) {
     const code = (e as NodeJS.ErrnoException)?.code;
     if (code === "EEXIST") throw new StudioConflictError();
+    if (created) {
+      await handle?.close().catch(() => undefined);
+      handle = undefined;
+      await unlink(finalPath).catch(() => undefined);
+    }
     throw new StudioWriteError();
   } finally {
     await handle?.close().catch(() => undefined);


### PR DESCRIPTION
## The bug

The `wx` open in `writeExclusive` **creates** the file. If the `writeFile` or `sync` that follows fails (ENOSPC, EIO, a quota), nothing cleans up, so a truncated file is left sitting at the destination.

The next attempt then hits `EEXIST` and surfaces as `StudioConflictError` -- "file already exists" -- for a piece the user never successfully saved. The orphan is permanent, so that piece can never be saved under its own name again.

Measured against current Mainstage, driving one ENOSPC through the handle:

```
before:  partial file left behind = true;   retry -> StudioConflictError, content ""
after:   partial file left behind = false;  retry -> ok, content {"v":2}
```

`writeAtomicReplace` already unlinks its temp on exactly this path, so the asymmetry looks like an oversight rather than a decision.

## The fix

A write that fails after creating the file removes it again, matching `writeAtomicReplace`.

The `created` flag is load-bearing. Without it, an open that fails for some reason *other* than `EEXIST` would unlink whatever sits at `finalPath`, and the cleanup would destroy the very file the exclusive open was protecting. That is not reachable today, since `O_EXCL` reports `EEXIST` before anything else, but the guard keeps it true if the open path ever grows.

## Tests

Three tests: no file left behind, the retry succeeds instead of hitting a phantom conflict, and cleanup never removes a file the call did not create. Two fail against current Mainstage.

**On the technique.** No portable filesystem trick summons ENOSPC on demand, so one `FileHandle.writeFile` is armed to throw once through the handle prototype, restored in a `finally` and again in `afterEach`. I first tried `mock.module` on `node:fs/promises` and backed it out: it recurses through the module it is mocking, and this repo has no mocking precedent to follow. The prototype patch is contained to a single test file that lives apart from the real-filesystem tests in `atomic-file.test.ts`, so it cannot reach them.

If you would rather not have a prototype patch in the suite at all, the alternative is making the `open` injectable and dropping the test to a plain stub. That widens the module's API for one test, which is why I did not reach for it, but say the word.

## Not included

`writeAtomicReplace` maps every failure to a bare `StudioWriteError`, so ENOSPC, EACCES, and EIO are indistinguishable in a bug report. Passing the original through as `cause` costs nothing and keeps `studioErr`'s path-scrubbing intact. Left out to keep this focused; happy to add.

## Verification

`bun test` full suite green (2751 pass, 0 fail), `tsc --noEmit` clean, style gates clean.

Written with Claude Opus 5, per the AI-assisted contribution note in CONTRIBUTING.md.