### PR TITLE
fix(lore): clamp a non-finite recursion budget instead of disabling the scan

### DIFF
--- a/src/core/lore/activation-recursion.test.ts
+++ b/src/core/lore/activation-recursion.test.ts
@@ -195,3 +195,37 @@ describe("golden: workshop-export + powers line", () => {
     expect(r.fired.map((f) => f.entryId).sort()).toEqual(["ember-echo", "revival-system"]);
   });
 });
+
+/**
+ * A non-finite recursion budget used to make maxLoops NaN, which made `loop <= maxLoops` false on
+ * the first check: the scan loop never ran, and every entry fell through to the no-key-match
+ * default. The verdict was the damaging part, since it blamed the book's keywords for an engine
+ * that never looked at them.
+ */
+describe("recursion budget clamping", () => {
+  const book = bookOf([entry("a", { triggers: [{ keyword: "hello", isRegex: false }] })]);
+  const chat = [line("hello there")];
+
+  test("a non-finite budget falls back to the default instead of disabling the scan", () => {
+    for (const bad of [NaN, Infinity, -Infinity]) {
+      const r = scanBook(book, chat, { chanceMode: "always", maxRecursionLoops: bad });
+      expect(r.fired.map((f) => f.entryId)).toEqual(["a"]);
+    }
+  });
+
+  test("a fractional budget truncates rather than poisoning the comparison", () => {
+    const r = scanBook(book, chat, { chanceMode: "always", maxRecursionLoops: 2.7 });
+    expect(r.fired.map((f) => f.entryId)).toEqual(["a"]);
+  });
+
+  test("zero still means no recursion, and the first pass still runs", () => {
+    const r = scanBook(book, chat, { chanceMode: "always", maxRecursionLoops: 0 });
+    expect(r.fired.map((f) => f.entryId)).toEqual(["a"]);
+    expect(r.loops).toBe(0);
+  });
+
+  test("an over-large budget is capped, not rejected", () => {
+    const r = scanBook(book, chat, { chanceMode: "always", maxRecursionLoops: 9999 });
+    expect(r.fired.map((f) => f.entryId)).toEqual(["a"]);
+  });
+});

--- a/src/core/lore/activation.ts
+++ b/src/core/lore/activation.ts
@@ -37,6 +37,21 @@ export type {
 export type { MatchOpts, KeywordHit } from "./match-keys";
 export { keywordMatches, resolveMatchOpts, secondaryLogicOk, firstTriggerHit } from "./match-keys";
 
+const DEFAULT_RECURSION_LOOPS = 3;
+const MAX_RECURSION_LOOPS = 10;
+
+/**
+ * Clamp the caller's recursion budget into range. Non-finite input takes the default rather than
+ * riding through: Math.max(NaN, 0) is NaN, and a NaN ceiling makes `loop <= maxLoops` false on the
+ * very first check, so the scan loop never runs at all and every entry falls through to the
+ * no-key-match default. That reads as "none of your keywords matched" when the truth is that the
+ * engine never looked, which is the worst possible verdict to show a creator debugging a book.
+ */
+function clampLoops(requested: number | undefined): number {
+  if (requested === undefined || !Number.isFinite(requested)) return DEFAULT_RECURSION_LOOPS;
+  return Math.min(Math.max(Math.trunc(requested), 0), MAX_RECURSION_LOOPS);
+}
+
 const emptyTimed = (turn = 0): TimedState => ({
   stickyLeft: {},
   cooldownLeft: {},
@@ -158,7 +173,7 @@ export function scanBook(
   lines: readonly ScanLine[],
   opts: ActivationOptions = { chanceMode: "always" },
 ): ActivationResult {
-  const maxLoops = Math.min(Math.max(opts.maxRecursionLoops ?? 3, 0), 10);
+  const maxLoops = clampLoops(opts.maxRecursionLoops);
   const rng = opts.rng ?? (() => 0.5);
   const prev = opts.turnState ?? emptyTimed(0);
   const stickyLeft: Record<string, number> = { ...prev.stickyLeft };


### PR DESCRIPTION
## The bug

```ts
const maxLoops = Math.min(Math.max(opts.maxRecursionLoops ?? 3, 0), 10);
```

`Math.max(NaN, 0)` is `NaN`, so a non-finite `maxRecursionLoops` makes `maxLoops` NaN, which makes `loop <= maxLoops` false on the very first check. **The scan loop body never executes at all**, and every entry then falls through to the `no-key-match` default at the end of `scanBook`.

```
normal maxRecursionLoops  -> fired: 1
NaN maxRecursionLoops     -> fired: 0, verdict: {"kind":"no-key-match"}
```

## Why the verdict is the damaging half

A book whose keywords are sitting right there in the chat reports "none of your keywords matched" when the engine never looked at them. That sends anyone debugging a book in exactly the wrong direction: they go rewrite working keywords.

## The fix

`clampLoops` takes the default for any non-finite input and truncates fractions. This matches the discipline `clampInt` already uses in `sandbox/lua/limits.ts:144`; the same guard just had not reached here.

Zero still means no recursion with the first pass intact, and an over-large budget is still capped rather than rejected.

## Tests

Four cases: non-finite (`NaN`, `Infinity`, `-Infinity`) falls back, fractional truncates, zero still runs the first pass, over-large is capped. The non-finite case fails against current Mainstage.

## Scope note

This is a robustness guard, not a report of a live crash. I found it by probing the engine's edges rather than from a bug in the wild, and I did not trace a caller that currently passes a non-finite value. It is cheap insurance on a path where the failure mode is silent and actively misleading, which is why I think it earns its place.

## Verification

`bun test` core/entities/formats green (1435 pass, 0 fail), `tsc --noEmit` clean.

Written with Claude Opus 5, per the AI-assisted contribution note in CONTRIBUTING.md.