### PR TITLE
fix(regex): make macro substitution order-independent

### DIFF
--- a/src/core/regex/replace-ops.test.ts
+++ b/src/core/regex/replace-ops.test.ts
@@ -231,3 +231,55 @@ describe("escapeRegexChars + applyTrim primitives", () => {
     expect(applyTrim("keep", [""])).toBe("keep"); // empty fragment is a no-op, never an infinite split
   });
 });
+
+/**
+ * Macro expansion resolves in ONE pass, so the result depends only on the map's contents and never
+ * on its insertion order. The previous per-key loop left text inserted by one key visible to every
+ * later key, so the same logical map produced different output depending on how it was built.
+ */
+describe("macro substitution is order-independent", () => {
+  test("a value that looks like another token is output, not re-expanded", () => {
+    expect(substituteMacros("[{{a}}]", { a: "{{b}}", b: "BOOM" }, false)).toBe("[{{b}}]");
+  });
+
+  test("the reverse insertion order gives exactly the same answer", () => {
+    const forward = substituteMacros("[{{a}}]", { a: "{{b}}", b: "BOOM" }, false);
+    const reverse = substituteMacros("[{{a}}]", { b: "BOOM", a: "{{b}}" }, false);
+    expect(forward).toBe(reverse);
+  });
+
+  test("a self-referential value does not loop or re-expand", () => {
+    expect(substituteMacros("[{{a}}]", { a: "{{a}}" }, false)).toBe("[{{a}}]");
+  });
+
+  test("independent tokens all resolve in the single pass", () => {
+    expect(substituteMacros("{{a}}-{{b}}-{{a}}", { a: "1", b: "2" }, false)).toBe("1-2-1");
+  });
+
+  test("an unknown token is left exactly as written", () => {
+    expect(substituteMacros("{{known}} {{unknown}}", { known: "yes" }, false)).toBe("yes {{unknown}}");
+  });
+
+  test("a key whose value is empty resolves to empty, not to a literal token", () => {
+    expect(substituteMacros("[{{k}}]", { k: "" }, false)).toBe("[]");
+  });
+
+  test("regex metacharacters in a KEY are matched literally, not as a pattern", () => {
+    expect(substituteMacros("[{{a.b}}]", { "a.b": "hit" }, false)).toBe("[hit]");
+    // the "." must not behave as a regex wildcard and match "axb"
+    expect(substituteMacros("[{{axb}}]", { "a.b": "hit" }, false)).toBe("[{{axb}}]");
+  });
+
+  test("spacing inside the braces is significant, as before", () => {
+    expect(substituteMacros("{{ user }}", { user: "Ada" }, false)).toBe("{{ user }}");
+  });
+
+  /**
+   * Documented limitation rather than a regression worth code: a macro KEY containing braces is not
+   * addressable, because the token grammar stops at the first brace so a stray "{{" cannot swallow
+   * the rest of the template. No real macro map uses brace keys; pinned so the tradeoff is explicit.
+   */
+  test("a key containing braces is not addressable", () => {
+    expect(substituteMacros("[{{a{b}}]", { "a{b": "hit" }, false)).toBe("[{{a{b}}]");
+  });
+});

--- a/src/core/regex/replace-ops.ts
+++ b/src/core/regex/replace-ops.ts
@@ -46,11 +46,25 @@ export function applyTrim(value: string, trimStrings: readonly string[]): string
   return out;
 }
 
+/** A `{{token}}`: no braces inside, so a stray `{{` cannot swallow the rest of the template. */
+const MACRO_TOKEN = /\{\{([^{}]*)\}\}/g;
+
 /**
  * Substitute {{key}} tokens from a flat macro map (case-insensitive); escape the substituted value
  * when `escapeValues` is set. A function replacer is used so a `$` inside a value is never itself
- * interpreted as a replacement token. Transcribed verbatim from apply.ts's current helper so apply
- * can delegate here losslessly.
+ * interpreted as a replacement token.
+ *
+ * ONE pass over the text, resolving each token against the map as it is met. The earlier
+ * implementation looped over the macro entries instead, running a global replace per key, which
+ * left text inserted by one key visible to every later key. That made the result depend on the
+ * map's insertion order:
+ *
+ *   { a: "{{b}}", b: "BOOM" }  ->  "[BOOM]"    // b's pass expanded what a had just inserted
+ *   { b: "BOOM", a: "{{b}}" }  ->  "[{{b}}]"   // b ran first, so a's token survived literally
+ *
+ * Same logical map, different output. A single pass makes the result depend only on the map's
+ * contents, and means a macro VALUE can never smuggle another macro token into the result: an
+ * inserted `{{b}}` is output, not input. Unknown tokens stay literal, as before.
  */
 export function substituteMacros(
   text: string,
@@ -58,13 +72,13 @@ export function substituteMacros(
   escapeValues: boolean,
 ): string {
   if (!macros) return text;
-  let out = text;
-  for (const [key, value] of Object.entries(macros)) {
-    const token = new RegExp(`\\{\\{${escapeRegexChars(key)}\\}\\}`, "gi");
-    const replacement = escapeValues ? escapeRegexChars(value) : value;
-    out = out.replace(token, () => replacement);
-  }
-  return out;
+  const lookup = new Map<string, string>();
+  for (const [key, value] of Object.entries(macros)) lookup.set(key.toLowerCase(), value);
+  return text.replace(MACRO_TOKEN, (whole, key: string) => {
+    const value = lookup.get(key.toLowerCase());
+    if (value === undefined) return whole; // not ours: leave it exactly as written
+    return escapeValues ? escapeRegexChars(value) : value;
+  });
 }
 
 /**


### PR DESCRIPTION
## The bug

`substituteMacros` looped over the macro entries, running one global replace per key. Text inserted by an early key stayed visible to every later key, so the result depended on the map's **insertion order**:

```js
substituteMacros("[{{a}}]", { a: "{{b}}", b: "BOOM" })  // -> "[BOOM]"
substituteMacros("[{{a}}]", { b: "BOOM", a: "{{b}}" })  // -> "[{{b}}]"
```

Same logical map, different output. Two problems in one: non-determinism relative to how the map was built, and a macro *value* able to smuggle another macro token into the expansion, which the author of a token map cannot see coming.

## The fix

One pass over the text, resolving each `{{token}}` against the map as it is met, so inserted text is output rather than input. The result now depends only on the map's contents.

Preserved exactly: unknown tokens stay literal, keys match case-insensitively and literally (a `.` in a key is not a wildcard), spacing inside the braces stays significant (`{{ user }}` does not resolve `user`, same as before), and a `$` in a value is still never read as a replacement token. This also drops one `RegExp` construction per macro per call.

## This is a behavior change

A value containing `{{b}}` used to expand sometimes. It now never does. That is the intended fix rather than a side effect, but if any format relies on chained macro values, this is the commit that changes it. I could not find one, but you would know better than I would.

**One documented limitation:** a macro key containing braces is no longer addressable, because the token grammar stops at the first brace so a stray `{{` cannot swallow the rest of a template. Pinned by a test so the tradeoff is explicit rather than accidental. No sample or fixture uses a brace key.

## Tests

Nine cases covering order-independence both directions, self-reference, independent tokens, unknown tokens, empty values, literal key matching, brace spacing, and the brace-key limitation. Three fail against current Mainstage.

All 547 existing regex tests pass unchanged, including the native-oracle parity suite.

## Verification

`bun test` full suite green (2757 pass, 0 fail), `tsc --noEmit` clean, style gates clean.

Written with Claude Opus 5, per the AI-assisted contribution note in CONTRIBUTING.md.