### PR TITLE
fix(kit): keep reasoning_content so thinking providers accept the history

### DIFF
--- a/src/kit/loop/loop-core.test.ts
+++ b/src/kit/loop/loop-core.test.ts
@@ -15,6 +15,27 @@ test("a plain answer yields one say and records the exchange", async () => {
   ]);
 });
 
+test("a reply's thinking is recorded with the assistant message it introduces", async () => {
+  // A DeepSeek-style backend rejects a history whose assistant turns lost the reasoning_content
+  // they originally carried, so the loop must persist the thought the reply opened with.
+  const call: ModelToolCall = { id: "c1", name: "list", args: {} };
+  const plain = await drain(runTurn("hi", [], deps(async () => ({
+    kind: "say",
+    text: "hello",
+    reasoning: "let me think",
+  }))));
+  expect(plain.history.at(-1)).toMatchObject(
+    { role: "assistant", content: "hello", reasoning: "let me think" },
+  );
+  const tooled = await drain(runTurn("list", [], deps(scripted([
+    { kind: "use", text: "", calls: [call], reasoning: "find them" },
+    { kind: "say", text: "here" },
+  ]))));
+  expect(tooled.history.find((m) => m.role === "assistant" && m.toolCalls?.length)).toMatchObject(
+    { role: "assistant", content: "", reasoning: "find them", toolCalls: [call] },
+  );
+});
+
 test("ReAct: calls a tool, observes the result, then answers", async () => {
   const call: ModelToolCall = { id: "c1", name: "list", args: { kind: "character" } };
   const chat = scripted([

--- a/src/kit/loop/loop-core.ts
+++ b/src/kit/loop/loop-core.ts
@@ -278,7 +278,7 @@ export async function* runTurn(
         lifecycle = initialLoopState();
         continue;
       }
-      messages.push({ role: "assistant", content: reply.text });
+      messages.push({ role: "assistant", content: reply.text, reasoning: reply.reasoning });
       yield { type: "say", text: reply.text };
       return messages;
     }
@@ -312,7 +312,12 @@ export async function* runTurn(
     }
 
     // Keep provider history valid: record tool calls only when this turn can answer all of them.
-    messages.push({ role: "assistant", content: reply.text, toolCalls: reply.calls });
+    messages.push({
+      role: "assistant",
+      content: reply.text,
+      toolCalls: reply.calls,
+      reasoning: reply.reasoning,
+    });
 
     const effectFor = (call: ModelToolCall): ToolEffect =>
       deps.effectFor?.(call) ?? "apply";

--- a/src/kit/providers/adapters.ts
+++ b/src/kit/providers/adapters.ts
@@ -29,6 +29,14 @@ export async function spokeChat(
   return spoke.chat(config, signal);
 }
 
+/** Whether the spoke requires assistant thinking to be echoed back onto the wire. Absent means no,
+ * so only a spoke that DECLARED the capability (its adapter carries reasoning parts back) ever does. */
+export async function spokeEchoesReasoning(config: ProviderConfig | null): Promise<boolean> {
+  if (!config) return false;
+  const spoke = (await spokes()).get(config.kind);
+  return spoke?.reasoningEcho === true;
+}
+
 /** Build the model for a config, or fail closed if it is unset, unknown, or missing a key. */
 export async function buildModel(config: ProviderConfig | null): Promise<LanguageModel> {
   if (!config) {

--- a/src/kit/providers/chat.test.ts
+++ b/src/kit/providers/chat.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The two wire mappers in the chat hub: thinking attaches only when the spoke declared it must
+ * echo, and the reply keeps the thought beside its answer so the loop can store it. These are the
+ * pure functions; the live stream is the same shape exercised end to end in a real run.
+ */
+import { expect, test } from "bun:test";
+import type { ModelMessage } from "./provider";
+import type { TokenUsage } from "./usage";
+import { toAiMessage, toReply } from "./chat";
+
+const usage: TokenUsage = {
+  input: 1,
+  output: 1,
+  total: 2,
+  cacheRead: 0,
+  cacheWrite: 0,
+  reasoning: 0,
+};
+
+test("toAiMessage attaches thinking only for a spoke that declared the echo", () => {
+  const reasoned: ModelMessage = {
+    role: "assistant",
+    content: "the answer",
+    reasoning: "the thought",
+  };
+  const echoed = toAiMessage(reasoned, true);
+  expect(echoed).toMatchObject({
+    role: "assistant",
+    content: [
+      { type: "reasoning", text: "the thought" },
+      { type: "text", text: "the answer" },
+    ],
+  });
+  // The safe default: a spoke that did NOT declare the echo gets the message exactly as before.
+  expect(toAiMessage(reasoned, false)).toMatchObject({
+    role: "assistant",
+    content: "the answer",
+  });
+});
+
+test("toAiMessage keeps thinking beside tool calls, ahead of them", () => {
+  const reasoned: ModelMessage = {
+    role: "assistant",
+    content: "let me look",
+    reasoning: "search first",
+    toolCalls: [{ id: "c1", name: "list", args: {} }],
+  };
+  const echoed = toAiMessage(reasoned, true);
+  expect(echoed.content).toEqual([
+    { type: "reasoning", text: "search first" },
+    { type: "text", text: "let me look" },
+    { type: "tool-call", toolCallId: "c1", toolName: "list", input: {} },
+  ]);
+});
+
+test("a message without thinking maps to its existing string shape", () => {
+  const plain: ModelMessage = { role: "assistant", content: "hi" };
+  expect(toAiMessage(plain, true)).toMatchObject({ role: "assistant", content: "hi" });
+});
+
+test("toReply carries the thought into both reply kinds", () => {
+  expect(toReply("hi", [], usage, "thought")).toEqual({
+    kind: "say",
+    text: "hi",
+    usage,
+    reasoning: "thought",
+  });
+  const calls = [{ toolCallId: "c1", toolName: "list", input: {} }];
+  expect(toReply("go", calls, usage, "thought")).toEqual({
+    kind: "use",
+    text: "go",
+    calls: [{ id: "c1", name: "list", args: {} }],
+    usage,
+    reasoning: "thought",
+  });
+});
+
+test("toReply without thinking keeps the prior exact shape", () => {
+  expect(toReply("hi", [], usage)).toEqual({
+    kind: "say",
+    text: "hi",
+    usage,
+  });
+});

--- a/src/kit/providers/chat.ts
+++ b/src/kit/providers/chat.ts
@@ -7,9 +7,12 @@
 import { jsonSchema, streamText, tool, type ModelMessage as AiMessage, type ImagePart, type TextPart, type ToolCallPart, type ToolSet } from "ai";
 import type { ChatFn, ModelMessage, ModelReply, ModelToolCall, ToolSpec } from "./provider";
 import type { ProviderConfig } from "./config";
-import { buildModel, spokeChat } from "./adapters";
+import { buildModel, spokeChat, spokeEchoesReasoning } from "./adapters";
 import { readUsage, type TokenUsage } from "./usage";
 import { KIT_TOOL_PROTOCOL } from "./tool-protocol";
+
+/** The SDK's assistant reasoning part (not re-exported by `ai`): thinking text beside the reply. */
+type ReasoningPart = { type: "reasoning"; text: string };
 
 /** Map the AI SDK's ragged usage object into a clean TokenUsage. Field names have drifted across SDK
  * majors (promptTokens/inputTokens, cachedInputTokens/cacheReadInputTokens), so we read tolerantly and
@@ -48,13 +51,15 @@ export function makeChat(
     const own = await spokeChat(config, abortSignal);
     if (own) return own(messages, tools, onDelta);
     const model = await buildModel(config);
+    // Only the active spoke decides whether thinking must travel back; see ProviderSpoke.reasoningEcho.
+    const echoReasoning = await spokeEchoesReasoning(config);
     const cap = AbortSignal.timeout(HANG_CAP_MS);
     const result = streamText({
       model,
       system: ambient ? `${KIT_TOOL_PROTOCOL}
 
 ${ambient()}` : KIT_TOOL_PROTOCOL,
-      messages: messages.map(toAiMessage),
+      messages: messages.map((message) => toAiMessage(message, echoReasoning)),
       tools: toAiTools(tools),
       toolChoice: "auto",
       abortSignal: abortSignal ? AbortSignal.any([abortSignal, cap]) : cap,
@@ -66,12 +71,21 @@ ${ambient()}` : KIT_TOOL_PROTOCOL,
         throw part.error instanceof Error ? part.error : new Error(String(part.error));
       }
     }
-    return toReply(await result.text, await result.toolCalls, mapUsage(await result.usage));
+    return toReply(
+      await result.text,
+      await result.toolCalls,
+      mapUsage(await result.usage),
+      // Some backends insist the thought they produced comes back with the next turn; keep it.
+      await result.reasoningText,
+    );
   };
 }
 
-/** Kit message -> AI SDK message, preserving assistant tool calls and tool results. */
-function toAiMessage(message: ModelMessage): AiMessage {
+/** Kit message -> AI SDK message, preserving assistant tool calls and tool results. Reasoning is
+ * attached only when the spoke DECLARED it must echo (reasoningEcho): for every other provider the
+ * part is signature-gated (anthropic, google), folded into text (mistral), or silently dropped
+ * (openai chat-completions), so the safe default is to leave it off the wire entirely. */
+export function toAiMessage(message: ModelMessage, echoReasoning: boolean): AiMessage {
   if (message.role === "user") {
     /**
      * Images ride as PARTS beside the text, which is the shape every vision model takes.
@@ -101,6 +115,16 @@ function toAiMessage(message: ModelMessage): AiMessage {
       ],
     };
   }
+  if (message.reasoning && echoReasoning) {
+    const parts: Array<ReasoningPart | TextPart | ToolCallPart> = [
+      { type: "reasoning", text: message.reasoning },
+    ];
+    if (message.content) parts.push({ type: "text", text: message.content });
+    for (const call of message.toolCalls ?? []) {
+      parts.push({ type: "tool-call", toolCallId: call.id, toolName: call.name, input: call.args });
+    }
+    return { role: "assistant", content: parts };
+  }
   if (message.toolCalls && message.toolCalls.length > 0) {
     const parts: Array<TextPart | ToolCallPart> = [];
     if (message.content) parts.push({ type: "text", text: message.content });
@@ -121,19 +145,21 @@ function toAiTools(specs: ToolSpec[]): ToolSet {
   return Object.fromEntries(entries);
 }
 
-/** AI SDK result -> our ModelReply: a plain answer, or a request to run tools, carrying this call's usage. */
-function toReply(
+/** AI SDK result -> our ModelReply: a plain answer, or a request to run tools, carrying this call's
+ * usage and - when the backend thought aloud - the thinking text, for spokes that must replay it. */
+export function toReply(
   text: string,
   toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input: unknown }>,
   usage: TokenUsage,
+  reasoning?: string,
 ): ModelReply {
   if (toolCalls.length === 0) {
-    return { kind: "say", text, usage };
+    return { kind: "say", text, usage, reasoning };
   }
   const calls: ModelToolCall[] = toolCalls.map((call) => ({
     id: call.toolCallId,
     name: call.toolName,
     args: call.input,
   }));
-  return { kind: "use", text, calls, usage };
+  return { kind: "use", text, calls, usage, reasoning };
 }

--- a/src/kit/providers/provider.ts
+++ b/src/kit/providers/provider.ts
@@ -9,6 +9,18 @@ import type { TokenUsage } from "./usage";
 export interface ModelMessage {
   role: "user" | "assistant" | "tool";
   content: string;
+  /**
+   * The model's thinking before it answered, when it thought aloud at all (assistant only).
+   *
+   * SOME OPENAI-COMPATIBLE BACKENDS REQUIRE IT BACK: a DeepSeek-style reasoning model will reject
+   * a conversation whose assistant turns lack the thinking they originally produced, so Kit keeps
+   * the raw thought with the message. Replay is provider-aware: a spoke that declares
+   * `reasoningEcho` gets the thought mapped back onto the wire; every other adapter either ignores
+   * the part it cannot carry or needs its own signature metadata, so the safe default is not to echo.
+   *
+   * Shell-stored, never rendered as speech: the reply's `content` is what the person reads.
+   */
+  reasoning?: string;
   /** On an assistant turn that invoked tools: the calls it made (adapters render these as tool_use). */
   toolCalls?: ModelToolCall[];
   /**
@@ -51,8 +63,8 @@ export interface ModelToolCall {
  * provider's reported token counts for this call (already cleaned), when it reported any; the meter and
  * tally read it. Optional: an OAI-compatible router that omits usage simply leaves it undefined. */
 export type ModelReply =
-  | { kind: "say"; text: string; usage?: TokenUsage }
-  | { kind: "use"; text: string; calls: ModelToolCall[]; usage?: TokenUsage };
+  | { kind: "say"; text: string; usage?: TokenUsage; reasoning?: string }
+  | { kind: "use"; text: string; calls: ModelToolCall[]; usage?: TokenUsage; reasoning?: string };
 
 /** How a tool looks to the model: name, description, and a JSON-schema for its args. */
 export interface ToolSpec {

--- a/src/kit/providers/reasoning-echo.test.ts
+++ b/src/kit/providers/reasoning-echo.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether thinking is ECHOED is the provider's answer, and these pin both halves of that.
+ *
+ * A DeepSeek-style reasoning backend rejects a history whose assistant turns lost the
+ * reasoning_content they originally produced ("The reasoning_content in the thinking mode must be
+ * passed back to the API"). Kit keeps the thought with the message, but only a spoke whose adapter
+ * carries the reasoning part back onto the wire may declare it echoes; every other adapter either
+ * signature-gates the block (anthropic, google), folds it into the visible text (mistral), or drops
+ * it silently (openai chat-completions), so for those the safe default is to leave the wire alone.
+ */
+import { describe, expect, test } from "bun:test";
+import { loadSpokes } from "./registry";
+
+describe("reasoning echo capability", () => {
+  test("the openai-compatible family and reasoning-aware SDKs declare it", async () => {
+    const spokes = await loadSpokes();
+    const declared = [...spokes.values()].filter((spoke) => spoke.reasoningEcho === true)
+      .map((speak) => speak.id).sort();
+    // Each of these maps an assistant reasoning part onto its request (reasoning_content for the
+    // openai-compatible family, a `reasoning` field for OpenRouter and Groq). A spoke gaining the
+    // echo adds one line and this list; the point is that the answer lives in the spoke file.
+    expect(declared).toEqual(["custom", "deepseek", "groq", "local", "nanogpt", "openrouter"]);
+  });
+
+  test("absent means no, so an undeclared provider never gets thinking attached", async () => {
+    const spokes = await loadSpokes();
+    // Mistral's adapter FOLDS a reasoning part into the assistant text: echoing would corrupt the
+    // wire message, so it must stay silent regardless of what Kit stored.
+    const mistral = spokes.get("mistral");
+    expect(mistral).toBeDefined();
+    expect(mistral?.reasoningEcho).toBeUndefined();
+    expect(mistral?.reasoningEcho === true).toBe(false);
+    const google = spokes.get("google");
+    expect(google?.reasoningEcho).toBeUndefined();
+  });
+
+  test("every spoke that declares it declares it as a literal true", async () => {
+    // Guards against a truthy-but-not-true value creeping in, since the whole system compares `=== true`.
+    for (const spoke of (await loadSpokes()).values()) {
+      if (spoke.reasoningEcho !== undefined) expect(spoke.reasoningEcho).toBe(true);
+    }
+  });
+});

--- a/src/kit/providers/spoke.ts
+++ b/src/kit/providers/spoke.ts
@@ -46,6 +46,18 @@ export interface ProviderSpoke {
    * turn - and a spoke that gains vision says so in one line.
    */
   images?: boolean;
+  /**
+   * Does this provider require assistant reasoning (thinking) content to be passed back on the wire?
+   *
+   * DECLARED, not assumed. The openai-compatible family expresses thinking as `reasoning_content`,
+   * and a DeepSeek-style reasoning backend REJECTS a history whose assistant turns lack the thought
+   * they originally produced ("The reasoning_content in the thinking mode must be passed back to
+   * the API"). Native adapters differ: anthropic and google need their own signature metadata and
+   * skip the block without it, openai chat-completions drops reasoning parts, and mistral would
+   * fold the thought into the visible text - so only a spoke whose SDK carries the field back
+   * declares this. Absent means NO, and Kit then never attaches the thought to a request.
+   */
+  reasoningEcho?: boolean;
   /** Provider-specific setup choices (plan tiers, endpoint variants). Rendered by the form. */
   options?: ReadonlyArray<SpokeOption>;
   /** Build the AI SDK model, lazy-importing the vendor adapter and wiring the guarded fetch.

--- a/src/kit/providers/spokes/custom.ts
+++ b/src/kit/providers/spokes/custom.ts
@@ -6,6 +6,9 @@ const custom: ProviderSpoke = {
   id: "custom",
   label: "Custom (OpenAI-compatible)",
   brand: "#E11D48",
+  // A pasted endpoint can sit in front of a DeepSeek-style reasoning model, and those backends
+  // REJECT a history that drops the reasoning_content their assistant turns originally carried.
+  reasoningEcho: true,
   // No fixed host: the egress allowlist is the user's base URL.
   async model({ apiKey, baseURL, headers, model }, fetch) {
     const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");

--- a/src/kit/providers/spokes/deepseek.ts
+++ b/src/kit/providers/spokes/deepseek.ts
@@ -8,6 +8,9 @@ const deepseek: ProviderSpoke = {
   brand: "#4D6BFE",
   host: "api.deepseek.com",
   defaultModel: "deepseek-chat",
+  // DeepSeek's reasoner REQUIRES thinking to be passed back: its API rejects a history whose
+  // assistant turns lack the reasoning_content they originally carried.
+  reasoningEcho: true,
   async model({ apiKey, baseURL, headers, model }, fetch) {
     const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
     return createOpenAICompatible({

--- a/src/kit/providers/spokes/groq.ts
+++ b/src/kit/providers/spokes/groq.ts
@@ -8,6 +8,8 @@ const groq: ProviderSpoke = {
   brand: "#F55036",
   host: "api.groq.com",
   defaultModel: "llama-3.3-70b-versatile",
+  // The Groq SDK maps assistant reasoning parts back to its own `reasoning` field (multi-turn thinking).
+  reasoningEcho: true,
   async model({ apiKey, baseURL, headers, model }, fetch) {
     const { createGroq } = await import("@ai-sdk/groq");
     return createGroq({ apiKey, baseURL, headers, fetch })(model);

--- a/src/kit/providers/spokes/local.ts
+++ b/src/kit/providers/spokes/local.ts
@@ -9,6 +9,8 @@ const local: ProviderSpoke = {
   // No fixed host: the egress allowlist is derived from the user's base URL (localhost).
   defaultModel: "llama3.1",
   keyless: true,
+  // Qwen3-class thinking trunks on Ollama/LM Studio answer in reasoning_content and expect it back.
+  reasoningEcho: true,
   async model({ apiKey, baseURL, headers, model }, fetch) {
     const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
     return createOpenAICompatible({

--- a/src/kit/providers/spokes/nanogpt.ts
+++ b/src/kit/providers/spokes/nanogpt.ts
@@ -18,6 +18,8 @@ const nanogpt: ProviderSpoke = {
   brand: "#34D399",
   host: "nano-gpt.com",
   defaultModel: "chatgpt-4o-latest",
+  // OpenAI-compatible behind a proxy that may run a reasoning model; the wire field is reasoning_content.
+  reasoningEcho: true,
   options: [
     {
       key: "plan",

--- a/src/kit/providers/spokes/openrouter.ts
+++ b/src/kit/providers/spokes/openrouter.ts
@@ -8,6 +8,8 @@ const openrouter: ProviderSpoke = {
   brand: "#94A3B8",
   host: "openrouter.ai",
   defaultModel: "anthropic/claude-opus-4-8",
+  // The OpenRouter SDK maps assistant reasoning parts back to its own `reasoning` field.
+  reasoningEcho: true,
   async model({ apiKey, baseURL, headers, model }, fetch) {
     const { createOpenRouter } = await import("@openrouter/ai-sdk-provider");
     return createOpenRouter({ apiKey, baseURL, headers, fetch }).chat(model);

--- a/src/kit/sessions/store.ts
+++ b/src/kit/sessions/store.ts
@@ -84,6 +84,7 @@ const parseMessage = (raw: unknown): ModelMessage | null => {
   return {
     role,
     content: raw["content"],
+    ...(typeof raw["reasoning"] === "string" ? { reasoning: raw["reasoning"] } : {}),
     ...(calls.length > 0 ? { toolCalls: calls } : {}),
     ...(typeof raw["toolCallId"] === "string" ? { toolCallId: raw["toolCallId"] } : {}),
     ...(typeof raw["toolName"] === "string" ? { toolName: raw["toolName"] } : {}),


### PR DESCRIPTION
Fixes an error from OpenAI-compatible thinking providers (seen on Console Go, a DeepSeek-style gateway):

> Error from provider (Console Go): Upstream request failed: [invalid_request_error] The `reasoning_content` in the thinking mode must be passed back to the API.

**Root cause.** A reasoning model answers with `reasoning_content` beside its content. DeepSeek-style backends REQUIRE that thinking to come back verbatim in the assistant turns of the next request; drop it and the API rejects the history. Kit streamed the thinking live (reasoning deltas) and then threw it away, and even where it was kept, the session store's message whitelist dropped it again on resume.

**Fix.** The thought now rides the wire end to end, gated by a per-spoke declaration:

- `ModelReply` and the stored `ModelMessage` keep the reply's reasoning text; `loop-core` records it on the assistant message, and the session store's `parseMessage` carries it across resume.
- `chat.ts` maps it onto the SDK message as a reasoning part (the openai-compatible adapter serializes that as `reasoning_content`) and reads it back from the response.
- Only spokes whose adapter carries the part back declare `reasoningEcho`: custom, deepseek, local, nanogpt, openrouter, groq. Anthropic and Google need signature metadata a replica cannot reconstruct, openai chat-completions drops the part, and mistral would fold the thought into the visible text, so those stay silent by default (absent means no, matching the `images` capability pattern).

**Proof.** Red-first: a reply's reasoning records into history (say and use), the wire mapper attaches the part only when the spoke declared the echo, and the declared set is pinned by a capability test mirroring `images.test.ts`. `verify:ci` is green; the only failures across many runs are the pre-existing Claude plan usage live tests hitting Anthropic 429s. (One under-load run also showed a single `not.toContain` failure that never reproduced across ten subsequent full-suite runs; the changed code is deterministic and was re-run 10x clean.)

AI model: DeepSeek V4 Flash (via pi, a coding agent).